### PR TITLE
optional useScript + process.stdout listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,10 @@ Unlike `VM`, `NodeVM` lets you require modules same way like in regular Node's c
 * `require` - `true` to enable `require` method (default: `false`)
 * `requireExternal` - `true` to enable `require` of external modules (default: `false`)
 * `requireNative` - Array of allowed native modules. (default: all available)
+* `fakeNative` - Array of faked native modules. Useful if you want to work with some modules that require e.g. fs but don't use it (default: `[]`)
+* `useStrict` - Whether the loaded module is loaded in strict mode (default: `true`)
 
-**Available modules:** `assert`, `buffer`, `child_process`, `crypto`, `tls`, `dgram`, `dns`, `http`, `https`, `net`, `querystring`, `url`, `domain`, `events`,  `fs`, `path`, `os`, `stream`, `string_decoder`, `timers`, `tty`,  `util`, `sys`, `vm`, `zlib`
+**Available modules:** `assert`, `buffer`, `child_process`, `constants`, `crypto`, `tls`, `dgram`, `dns`, `http`, `https`, `net`, `querystring`, `url`, `domain`, `events`,  `fs`, `path`, `os`, `stream`, `string_decoder`, `timers`, `tty`,  `util`, `sys`, `vm`, `zlib`
 
 Remember: the more modules you allow, the more fragile your sandbox becomes.
 

--- a/package.json
+++ b/package.json
@@ -26,10 +26,9 @@
 		}
 	],
 	"dependencies": {
-		
+		"coffee-script": "1.9.0"
 	},
 	"devDependencies": {
-		"coffee-script": "1.9.0",
 		"mocha": "^1.12.0"
 	},
 	"engines": {
@@ -37,6 +36,7 @@
 	},
 	"scripts": {
 		"test": "mocha",
+		"postinstall": "npm run build",
 		"build": "coffee -b -o lib -c src",
 		"watch": "coffee -w -b -o lib -c src"
 	},

--- a/package.json
+++ b/package.json
@@ -1,46 +1,47 @@
 {
-	"author": {
-		"name": "Patrik Simek",
-		"url": "https://patriksimek.cz"
-	},
-	"name": "vm2",
-	"description": "vm2 is a sandbox that can run untrusted code with whitelisted built-in node objects. Securely!.",
-	"keywords": [
-		"sandbox",
-		"prison",
-		"jail",
-		"vm",
-		"alcatraz",
-		"contextify"
-	],
-	"version": "0.2.2",
-	"main": "index.js",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/patriksimek/vm2"
-	},
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "http://opensource.org/licenses/mit-license.php"
-		}
-	],
-	"dependencies": {
-		"coffee-script": "1.9.0"
-	},
-	"devDependencies": {
-		"mocha": "^1.12.0"
-	},
-	"engines": {
-		"node": ">=0.11"
-	},
-	"scripts": {
-		"test": "mocha",
-		"postinstall": "npm run build",
-		"build": "coffee -b -o lib -c src",
-		"watch": "coffee -w -b -o lib -c src"
-	},
-	"bin": {
-		"vm2": "./bin/vm2"
-	}
+  "author": {
+    "name": "Patrik Simek",
+    "url": "https://patriksimek.cz"
+  },
+  "name": "vm2",
+  "description": "vm2 is a sandbox that can run untrusted code with whitelisted built-in node objects. Securely!.",
+  "keywords": [
+    "sandbox",
+    "prison",
+    "jail",
+    "vm",
+    "alcatraz",
+    "contextify"
+  ],
+  "version": "0.2.2",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/patriksimek/vm2"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://opensource.org/licenses/mit-license.php"
+    }
+  ],
+  "dependencies": {
+    "buffer": "^3.0.3",
+    "coffee-script": "1.9.0"
+  },
+  "devDependencies": {
+    "mocha": "^1.12.0"
+  },
+  "engines": {
+    "node": ">=0.11"
+  },
+  "scripts": {
+    "test": "mocha",
+    "postinstall": "npm run build",
+    "build": "coffee -b -o lib -c src",
+    "watch": "coffee -w -b -o lib -c src"
+  },
+  "bin": {
+    "vm2": "./bin/vm2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -29,14 +29,16 @@
 		
 	},
 	"devDependencies": {
-		"coffee-script": "^1.8.0",
+		"coffee-script": "1.9.0",
 		"mocha": "^1.12.0"
 	},
 	"engines": {
 		"node": ">=0.11"
 	},
 	"scripts": {
-		"test": "mocha"
+		"test": "mocha",
+		"build": "coffee -b -o lib -c src",
+		"watch": "coffee -w -b -o lib -c src"
 	},
 	"bin": {
 		"vm2": "./bin/vm2"

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -15,16 +15,17 @@ AVAILABLE_NATIVE_MODULES = [
 	'assert',
 	'buffer',
 	'child_process',
-	'crypto', 'tls', 
+	'constants',
+	'crypto', 'tls',
 	'dgram', 'dns', 'http', 'https', 'net', 'querystring', 'url',
 	'domain',
-	'events', 
+	'events',
 	'fs', 'path',
 	'os',
 	'stream',
 	'string_decoder',
 	'timers',
-	'tty', 
+	'tty',
 	'util', 'sys',
 	'vm',
 	'zlib'
@@ -50,7 +51,7 @@ _prepareContextify = (value) ->
 		if value instanceof Date then return value
 		if value instanceof RegExp then return value
 		if value instanceof Buffer then return value
-		
+
 		o = {}
 		o[k] = _prepareContextify v for k, v of value
 		return o
@@ -62,10 +63,10 @@ _compileToJS = (code, language) ->
 	switch language
 		when 'coffeescript', 'coffee-script', 'cs', 'text/coffeescript'
 			return require('coffee-script').compile code, {header: false, bare: true}
-		
+
 		when 'javascript', 'java-script', 'js', 'text/javascript'
 			return code
-		
+
 		else
 			throw new VMError "Unsupported language '#{language}'."
 
@@ -81,66 +82,66 @@ class VM extends EventEmitter
 	running: false
 	options: null
 	context: null
-	
+
 	###
 	Create VM instance.
-	
+
 	@param {Object} [options] VM options.
 	@return {VM}
 	###
-	
+
 	constructor: (options = {}) ->
 		# defaults
 		@options =
 			timeout: options.timeout ? undefined
 			sandbox: options.sandbox ? null
 			language: options.language ? 'javascript'
-	
+
 	###
 	Run the code in VM.
-	
+
 	@param {String} code Code to run.
 	@return {*} Result of executed code.
 	###
-	
+
 	run: (code) ->
 		'use strict'
 
 		if @options.language isnt 'javascript'
 			code = _compileToJS code, @options.language
-		
+
 		if @running
 			script = new vm.Script code,
 				filename: "vm"
 				displayErrors: false
-				
+
 			return script.runInContext @context,
 				filename: "vm"
 				displayErrors: false
 				timeout: @options.timeout
-		
+
 		@context = vm.createContext()
 		contextify = vm.runInContext("(function(require) { #{cf} \n})", @context, {filename: "contextify.js", displayErrors: false}).call @context, require
-		
+
 		# prepare global sandbox
 		if @options.sandbox
 			unless typeof @options.sandbox is 'object'
 				throw new VMError "Sandbox must be object"
-			
+
 			for name, value of @options.sandbox
 				contextify _prepareContextify(value), name
-		
+
 		script = new vm.Script code,
 			filename: "vm"
 			displayErrors: false
-		
+
 		# run script
 		@running = true
 		script.runInContext @context,
 			filename: "vm"
 			displayErrors: false
 			timeout: @options.timeout
-		
+
 ###
 Class NodeVM.
 
@@ -155,20 +156,20 @@ class NodeVM extends VM
 	natives: null # cache of native modules
 	module: null
 	proxy: null
-	
+
 	###
 	Create NodeVM instance.
-	
+
 	Unlike VM, NodeVM lets you use require same way like in regular node.
-	
+
 	@param {Object} [options] VM options.
 	@return {NodeVM}
 	###
-	
+
 	constructor: (options = {}) ->
 		#@cache is initialized inside vm's context (security reasons)
 		@natives = {}
-		
+
 		# defaults
 		@options =
 			sandbox: options.sandbox ? null
@@ -177,63 +178,65 @@ class NodeVM extends VM
 			language: options.language ? 'javascript'
 			requireExternal: options.requireExternal ? false
 			requireNative: {}
+			fakeNative: options.fakeNative ? []
+			useStrict: options.useStrict ? true
 
 		# convert array of modules to collection to speed things up
 		if options.requireNative
 			if Array.isArray options.requireNative
 				@options.requireNative[mod] = true for mod in options.requireNative when mod in AVAILABLE_NATIVE_MODULES
-			
+
 		else
 			# by default, add all available native modules
 			@options.requireNative[mod] = true for mod in AVAILABLE_NATIVE_MODULES
-	
+
 	###
-	Securely call method in VM. All arguments except functions are cloned during the process to prevent context leak. Functions are wrapped to secure closures. 
-	
+	Securely call method in VM. All arguments except functions are cloned during the process to prevent context leak. Functions are wrapped to secure closures.
+
 	Buffers are copied!
-	
+
 	IMPORTANT: Method doesn't check for circular objects! If you send circular structure as an argument, you process will stuck in infinite loop.
-	
+
 	@param {Function} method Method to execute.
 	@param {...*} argument Arguments.
 	@return {*} Return value of executed method.
 	###
-	
+
 	call: (method) ->
 		'use strict'
-		
+
 		unless @running
 			throw new VMError "VM is not running"
-		
+
 		if typeof method is 'function'
 			return @proxy arguments...
 
 		else
 			throw new VMError "Unrecognized method type"
-	
+
 	###
-	Run the code in NodeVM. 
-	
+	Run the code in NodeVM.
+
 	First time you run this method, code is executed same way like in node's regular `require` - it's executed with `module`, `require`, `exports`, `__dirname`, `__filename` variables and expect result in `module.exports'.
-	
+
 	@param {String} code Code to run.
 	@param {String} [filename] Filename that shows up in any stack traces produced from this script.
 	@return {*} Result of executed code.
 	###
-	
+
 	run: (code, filename) ->
 		'use strict'
-		
+
 		if global.isVM
 			throw new VMError "You can't nest VMs"
-		
+
 		if @options.language isnt 'javascript'
 			code = _compileToJS code, @options.language
 
 		if filename
 			filename = pa.resolve filename
 			dirname = pa.dirname filename
-		
+
 		else
 			filename = null
 			dirname = null
@@ -242,7 +245,7 @@ class NodeVM extends VM
 			script = new vm.Script code,
 				filename: filename ? "vm"
 				displayErrors: false
-				
+
 			return script.runInContext @context,
 				filename: filename ? "vm"
 				displayErrors: false
@@ -258,7 +261,7 @@ class NodeVM extends VM
 			clearTimeout: clearTimeout
 			clearInterval: clearInterval
 			clearImmediate: clearImmediate
-		
+
 		if global.DTRACE_HTTP_SERVER_RESPONSE
 			parent.DTRACE_HTTP_SERVER_RESPONSE = global.DTRACE_HTTP_SERVER_RESPONSE
 			parent.DTRACE_HTTP_SERVER_REQUEST = global.DTRACE_HTTP_SERVER_REQUEST
@@ -268,7 +271,7 @@ class NodeVM extends VM
 			parent.DTRACE_NET_SERVER_CONNECTION = global.DTRACE_NET_SERVER_CONNECTION
 			parent.DTRACE_NET_SOCKET_READ = global.DTRACE_NET_SOCKET_READ
 			parent.DTRACE_NET_SOCKET_WRITE = global.DTRACE_NET_SOCKET_WRITE
-		
+
 		if global.COUNTER_NET_SERVER_CONNECTION
 			parent.COUNTER_NET_SERVER_CONNECTION = global.COUNTER_NET_SERVER_CONNECTION
 			parent.COUNTER_NET_SERVER_CONNECTION_CLOSE = global.COUNTER_NET_SERVER_CONNECTION_CLOSE
@@ -276,22 +279,22 @@ class NodeVM extends VM
 			parent.COUNTER_HTTP_SERVER_RESPONSE = global.COUNTER_HTTP_SERVER_RESPONSE
 			parent.COUNTER_HTTP_CLIENT_REQUEST = global.COUNTER_HTTP_CLIENT_REQUEST
 			parent.COUNTER_HTTP_CLIENT_RESPONSE = global.COUNTER_HTTP_CLIENT_RESPONSE
-		
+
 		@context = vm.createContext()
 		contextify = vm.runInContext("(function(require) { #{cf} \n})", @context, {filename: "contextify.js", displayErrors: false}).call @context, require
-		
+
 		closure = vm.runInContext "(function (vm, parent, contextify, __dirname, __filename) { #{sb} \n})", @context,
 			filename: "sandbox.js"
 			displayErrors: false
-		
+
 		{@cache, @module, @proxy} = closure.call @context, @, parent, contextify, dirname, filename
 		@cache[filename] = @module
-		
+
 		# prepare global sandbox
 		if @options.sandbox
 			unless typeof @options.sandbox is 'object'
 				throw new VMError "Sandbox must be object"
-			
+
 			for name, value of @options.sandbox
 				contextify _prepareContextify(value), name
 
@@ -300,7 +303,7 @@ class NodeVM extends VM
 		script = new vm.Script "(function (exports, require, module, __filename, __dirname) { #{code} \n})",
 			filename: filename ? "vm"
 			displayErrors: false
-			
+
 		closure = script.runInContext @context,
 			filename: filename ? "vm"
 			displayErrors: false
@@ -311,48 +314,48 @@ class NodeVM extends VM
 
 	###
 	Create NodeVM and run code inside it.
-	
+
 	@param {String} script Javascript code.
 	@param {String} [filename] File name (used in stack traces only).
 	@param {Object} [options] VM options.
 	@return {NodeVM} VM.
 	###
-	
+
 	@code: (script, filename, options) ->
 		if filename?
 			if typeof filename is 'object'
 				options = filename
 				filename = null
-			
+
 			else if typeof filename is 'string'
 				filename = pa.resolve filename
-			
+
 			else
 				console.log arguments
 				throw new VMError "Invalid arguments"
-		
+
 		if arguments.length > 3
 			throw new VMError "Invalid number of arguments"
-		
+
 		_vm = new NodeVM options
 		_vm.run script, filename
 		_vm
-	
+
 	###
 	Create NodeVM and run script from file inside it.
-	
+
 	@param {String} [filename] File name (used in stack traces only).
 	@param {Object} [options] VM options.
 	@return {NodeVM} VM.
 	###
-	
+
 	@file: (filename, options) ->
 		_vm = new NodeVM options
 		filename = pa.resolve filename
-		
+
 		unless fs.existsSync filename
 			throw new VMError "Script '#{filename}' not found"
-		
+
 		if fs.statSync(filename).isDirectory()
 			throw new VMError "Script must be file, got directory"
 
@@ -374,7 +377,7 @@ class VMError extends Error
 	constructor: (message) ->
 		@name = @constructor.name
 		@message = message
-		
+
 		super()
 		Error.captureStackTrace @, @constructor
 

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -281,7 +281,12 @@ class NodeVM extends VM
 			parent.COUNTER_HTTP_CLIENT_RESPONSE = global.COUNTER_HTTP_CLIENT_RESPONSE
 
 		@context = vm.createContext()
-		contextify = vm.runInContext("(function(require) { #{cf} \n})", @context, {filename: "contextify.js", displayErrors: false}).call @context, require
+		opts =
+			filename: "contextify.js"
+			displayErrors: false
+		if @options.timeout
+			opts.timeout = timeout
+		contextify = vm.runInContext("(function(require) { #{cf} \n})", @context, opts).call @context, require
 
 		closure = vm.runInContext "(function (vm, parent, contextify, __dirname, __filename) { #{sb} \n})", @context,
 			filename: "sandbox.js"

--- a/src/sandbox.coffee
+++ b/src/sandbox.coffee
@@ -63,6 +63,11 @@ return do (vm, parent) =>
 	_requireNative = (modulename) ->
 		'use strict'
 
+		if modulename is "buffer"
+      # use the pure JS version of buffer as the native does some crazy binding
+      # and somehow crashes the non-contexted buffer
+			modulename = "buffer/"
+
 		if vm.natives[modulename]
 			return vm.natives[modulename].exports
 

--- a/src/sandbox.coffee
+++ b/src/sandbox.coffee
@@ -13,7 +13,7 @@ EXTENSIONS =
 ###
 
 return do (vm, parent) =>
-	'use strict'
+  #'use strict'
 
 	# setup sandbox global
 	global = @
@@ -26,50 +26,50 @@ return do (vm, parent) =>
 
 	_resolveFilename = (path) ->
 		path = pa.resolve path
-		
+
 		exists = fs.existsSync(path)
 		isdir = if exists then fs.statSync(path).isDirectory() else false
-	
+
 		# direct file match
 		if exists and not isdir then return path
-		
+
 		# load as file
-		
+
 		if fs.existsSync "#{path}.js" then return "#{path}.js"
 		if fs.existsSync "#{path}.node" then return "#{path}.node"
 		if fs.existsSync "#{path}.json" then return "#{path}.json"
-	
+
 		# load as directory
-		
+
 		if fs.existsSync "#{path}/package.json"
 			try
 				pkg = JSON.parse fs.readFileSync("#{path}/package.json", "utf8")
 				pkg.main ?= "index.js"
-				
+
 			catch ex
 				throw new VMError "Module '#{modulename}' has invalid package.json", "EMODULEINVALID"
-				
+
 			return _resolveFilename "#{path}/#{pkg.main}"
-			
+
 		if fs.existsSync "#{path}/index.js" then return "#{path}/index.js"
 		if fs.existsSync "#{path}/index.node" then return "#{path}/index.node"
-	
+
 		null
 
 	###
 	Prepare require.
 	###
-	
+
 	_requireNative = (modulename) ->
 		'use strict'
-		
+
 		if vm.natives[modulename]
 			return vm.natives[modulename].exports
 
 		# precompile native source
-		script = new Script "(function (exports, require, module, process) { 'use strict'; #{NATIVE_MODULES[modulename]} \n});", 
+		script = new Script "(function (exports, require, module, process) { 'use strict'; #{NATIVE_MODULES[modulename]} \n});",
 			filename: "#{modulename}.sb.js"
-		
+
 		# setup module scope
 		vm.natives[modulename] = module =
 			exports: {}
@@ -79,132 +79,141 @@ return do (vm, parent) =>
 		script.runInContext(global) module.exports, module.require, module, parent.process
 
 		return module.exports
-	
+
 	_prepareRequire = (current_dirname) ->
 		_require = (modulename) ->
 			# make sure vm cant access this function via arguments.callee.caller
 			'use strict'
-			
+
 			unless vm.options.require
 				throw new VMError "Access denied to require '#{modulename}'", "EDENIED"
-			
+
 			unless modulename?
 				throw new VMError "Module '' not found.", "ENOTFOUND"
-				
+
 			if typeof modulename isnt 'string'
 				throw new VMError "Invalid module name '#{modulename}'", "EINVALIDNAME"
-	
+
 			# Is module native module
-			
+
 			if NATIVE_MODULES[modulename]
 				if vm.options.requireNative
 					if vm.options.requireNative[modulename]
 						return _requireNative modulename
-				
-				throw new VMError "Access denied to require '#{modulename}'", "EDENIED"
-			
+
+				if vm.options.fakeNative.indexOf modulename >= 0
+					# some node modules require fs at the beginning even if they dont need
+					# BE careful with this option
+					return {}
+				else
+					throw new VMError "Access denied to require '#{modulename}'", "EDENIED"
+
 			unless vm.options.requireExternal
 				throw new VMError "Access denied to require '#{modulename}'", "EDENIED"
-	
+
 			if /^(\.\/|\.\.\/)/.exec modulename
 				# Module is relative file, e.g. ./script.js or ../script.js
-	
+
 				filename = _resolveFilename "#{current_dirname}/#{modulename}"
-			
+
 			else if /^(\/|\\|[a-zA-Z]:\\)/.exec modulename
 				# Module is absolute file, e.g. /script.js or //server/script.js or C:\script.js
-	
+
 				filename = _resolveFilename modulename
-	
+
 			else
 				# Check node_modules in path
 
 				paths = current_dirname.split pa.sep
-				
+
 				while paths.length
 					path = paths.join pa.sep
-					
+
 					#console.log modulename, "#{path}#{pa.sep}node_modules#{pa.sep}#{modulename}"
-					
+
 					filename = _resolveFilename "#{path}#{pa.sep}node_modules#{pa.sep}#{modulename}"
 					if filename then break
-	
+
 					paths.pop()
-				
+
 			unless filename
 				throw new VMError "Module '#{modulename}' not found", "ENOTFOUND"
-			
+
 			# return cache whenever possible
 			if vm.cache[filename]
 				return vm.cache[filename].exports
-			
+
 			dirname = pa.dirname filename
 			extname = pa.extname filename
-			
+
 			vm.cache[filename] = module =
 				filename: filename
 				exports: {}
 				require: _prepareRequire dirname
-			
+				paths: []
+
 			# lookup extensions
-			
+
 			if EXTENSIONS[extname]
 				try
 					EXTENSIONS[extname] module, filename
 					return module.exports
-					
+
 				catch ex
 					throw new VMError "Failed to load '#{filename}': [#{ex.message}]", "ELOADFAIL"
 
 			# Watch for .node
-			
+
 			if extname is '.node'
 				try
 					parent.process.dlopen module, filename
 					return module.exports
-					
+
 				catch ex
 					throw new VMError "Failed to load '#{filename}': [#{ex.message}]", "ELOADFAIL"
-			
+
 			# Watch for .js
-	
+
 			try
 				# Load module
-				code = "(function (exports, require, module, __filename, __dirname) { 'use strict'; #{fs.readFileSync(filename, "utf8")} \n});"
-				
+				if vm.options.useStrict
+					strictText = "'use strict';"
+				else
+					strictText = ""
+				code = "(function (exports, require, module, __filename, __dirname) { #{strictText} #{fs.readFileSync(filename, "utf8")} \n});"
 			catch ex
 				throw new VMError "Failed to load '#{filename}': [#{ex.message}]", "ELOADFAIL"
-	
+
 			# Precompile script
-			script = new Script code, 
+			script = new Script code,
 				filename: filename ? "vm"
 				displayErrors: false
-			
-			closure = script.runInContext global, 
+
+			closure = script.runInContext global,
 				filename: filename ? "vm"
 				displayErrors: false
 
 			# run script
 			closure module.exports, module.require, module, filename, dirname
-	
+
 			module.exports
-		
+
 		_require.cache = vm.cache
 		_require.extensions = EXTENSIONS
 		_require
-	
+
 	###
 	Prepare sandbox.
 	###
-	
+
 	global.setTimeout = (callback) ->
-		arguments[0] = -> callback.call null
+		#arguments[0] = -> callback.call null
 		parent.setTimeout arguments...
 	global.setInterval = (callback) ->
-		arguments[0] = -> callback.call null
+		#arguments[0] = -> callback.call null
 		parent.setInterval arguments...
 	global.setImmediate = (callback) ->
-		arguments[0] = -> callback.call null
+		#arguments[0] = -> callback.call null
 		parent.setImmediate arguments...
 	global.clearTimeout = -> parent.clearTimeout arguments...
 	global.clearInterval = -> parent.clearInterval arguments...
@@ -221,8 +230,13 @@ return do (vm, parent) =>
 		nextTick: (callback) -> parent.process.nextTick -> callback.call null
 		hrtime: -> parent.process.hrtime()
 		cwd: -> parent.process.cwd()
-	
+		on: (name) ->
+			#console.log("unable to subscribe to "+ name)
+		removeListener: (name) ->
+			#console.log("unable to remove "+ name)
+
 	if vm.options.console is 'inherit'
+		global.process.stdout = parent.process.stdout
 		global.console =
 			log: -> parent.console.log arguments...
 			info: -> parent.console.info arguments...
@@ -232,8 +246,11 @@ return do (vm, parent) =>
 			time: -> parent.console.time arguments...
 			timeEnd: -> parent.console.timeEnd arguments...
 			trace: -> parent.console.trace arguments...
-	
+
 	else if vm.options.console is 'redirect'
+		global.process.stdout =
+			getWindowSize: parent.process.stdout.getWindowSize
+			write: -> vm.emit "process.write", arguments...
 		global.console =
 			log: -> vm.emit 'console.log', arguments...
 			info: -> vm.emit 'console.info', arguments...
@@ -243,7 +260,7 @@ return do (vm, parent) =>
 			time: -> noop
 			timeEnd: -> noop
 			trace: -> vm.emit 'console.trace', arguments...
-	
+
 	if parent.DTRACE_HTTP_SERVER_RESPONSE
 		global.DTRACE_HTTP_SERVER_RESPONSE = -> parent.DTRACE_HTTP_SERVER_RESPONSE arguments...
 		global.DTRACE_HTTP_SERVER_REQUEST = -> parent.DTRACE_HTTP_SERVER_REQUEST arguments...
@@ -253,7 +270,7 @@ return do (vm, parent) =>
 		global.DTRACE_NET_SERVER_CONNECTION = -> parent.DTRACE_NET_SERVER_CONNECTION arguments...
 		global.DTRACE_NET_SOCKET_READ = -> parent.DTRACE_NET_SOCKET_READ arguments...
 		global.DTRACE_NET_SOCKET_WRITE = -> parent.DTRACE_NET_SOCKET_WRITE arguments...
-	
+
 	if parent.COUNTER_NET_SERVER_CONNECTION
 		global.COUNTER_NET_SERVER_CONNECTION = -> parent.COUNTER_NET_SERVER_CONNECTION arguments...
 		global.COUNTER_NET_SERVER_CONNECTION_CLOSE = -> parent.COUNTER_NET_SERVER_CONNECTION_CLOSE arguments...
@@ -273,20 +290,21 @@ return do (vm, parent) =>
 			@name = @constructor.name
 			@message = message
 			@code = code
-			
+
 			super()
 			Error.captureStackTrace @, @constructor
-	
+
 	###
 	Return contextized variables.
 	###
- 
+
 	cache: {}
 	module:
 		filename: __filename
 		exports: {}
 		require: _prepareRequire __dirname
-	
+		paths: []
+
 	proxy: (method, args...) ->
 		args[index] = contextify arg for arg, index in args
 		method.apply null, args


### PR DESCRIPTION
Hi, 

Congrats for this great module!
I wanted to run `mocha` tests in a sandbox with `vm2` (both tests and code is from an unknown source).
Therefore I had to do a couple of modifications to vm2 - feel free to use them.

Some remarks:
* I had to remove `use strict` in the sandbox module, because otherwise it can't access the `arguments` variable for `setTimer`, `setInterval` and `setImmediate`
* I use fakeNative for `fs` as some modules and submodules from mocha require `fs` at their module header, but I don't want to expose the filesystem
* Looking at `setTimer`, `setInterval`: commented first line `arguments[0] = -> callback.call null` out, as the native module handles that
* sorry that my vim replaced all newlines with empty newlines - I can rebase that it if you want ;-)

Thanks again for this great package!

Detailed list of changes:

* added coffee-script build script to package.json
* added options (with doc)
 -  useStrict
 -  fakeNative
* `constants` is a native module too
* event listener for process.stdout
* fake `process.on`
* fake `module.paths`
* I use the exact coffee-script version 1.9.0, because for 19.1 there is a bug with the file watching

Cheers,

Seb