### PR TITLE
Fixed setTimeout and setInterval

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -259,10 +259,10 @@ return ((vm, host) => {
 	 * Prepare sandbox.
 	 */
 	
-	global.setTimeout = function(callback, ...args) {
+	global.setTimeout = function(callback, delay, ...args) {
 		let tmr = host.setTimeout(function() {
 			callback.apply(null, args)
-		});
+		}, delay);
 		
 		let local = {
 			ref() { return tmr.ref(); },
@@ -273,10 +273,10 @@ return ((vm, host) => {
 		return local;
 	};
 		
-	global.setInterval = function(callback, ...args) {
+	global.setInterval = function(callback, interval, ...args) {
 		let tmr = host.setInterval(function() {
 			callback.apply(null, args)
-		});
+		}, interval);
 		
 		let local = {
 			ref() { return tmr.ref(); },


### PR DESCRIPTION
The setTimeout and setInterval functions of the sandbox were missing the interval arguments.
This fixes #34.