### PR TITLE
fixing issue #44

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -88,6 +88,7 @@ class VM extends EventEmitter {
 		this._context = vm.createContext();
 
 		Reflect.defineProperty(this, '_internal', {
+			configurable: true,
 			value: vm.runInContext(`(function(require, host) { ${cf} \n})`, this._context, {
 				filename: `${__dirname}/contextify.js`,
 				displayErrors: false
@@ -234,6 +235,7 @@ class NodeVM extends EventEmitter {
 		this._context = vm.createContext();
 
 		Object.defineProperty(this, '_internal', {
+			configurable: true,
 			value: vm.runInContext(`(function(require, host) { ${cf} \n})`, this._context, {
 				filename: `${__dirname}/contextify.js`,
 				displayErrors: false
@@ -246,6 +248,7 @@ class NodeVM extends EventEmitter {
 		})
 
 		Object.defineProperty(this, '_prepareRequire', {
+			configurable: true,
 			value: closure.call(this._context, this, host, this._internal.Contextify, this._internal.Decontextify, this._internal.Buffer)
 		})
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -44,6 +44,14 @@ class VM extends EventEmitter {
 	constructor(options = {}) {
 		super();
 
+		this.createNewContext(options);
+	}
+
+	/**
+	 * Create a new context, same arguments as constructor
+	 * @param {Object} [options] VM options.
+	 */
+	createNewContext(options = {}) {
 		// defaults
 		this.options = {
 			timeout: options.timeout != null ? options.timeout : undefined,
@@ -99,22 +107,29 @@ class VM extends EventEmitter {
 	}
 
 	/**
-	 * Run the code in VM.
+	 * Compile code and return object, can assist with performance
 	 *
 	 * @param {String} code Code to run.
-	 * @return {*} Result of executed code.
+	 * @returns {vm.Script}
 	 */
-
-	run(code) {
+	compile(code) {
 		if (this.options.compiler !== 'javascript') {
 			code = _compileToJS(code, this.options.compiler);
 		}
 
-		let script = new vm.Script(code, {
+		return new vm.Script(code, {
 			filename: "vm.js",
 			displayErrors: false
 		});
+	}
 
+	/**
+	 * Executes a compiled script and returns results
+	 *
+	 * @param {vm.Script} script Script to execute
+	 * @returns {*} Result of executed code
+	 */
+	execute(script) {
 		try {
 			return this._internal.Decontextify.value(script.runInContext(this._context, {
 				filename: "vm.js",
@@ -124,6 +139,18 @@ class VM extends EventEmitter {
 		} catch (e) {
 			throw this._internal.Decontextify.value(e);
 		}
+	}
+
+	/**
+	 * Run the code in VM.
+	 *
+	 * @param {String} code Code to run.
+	 * @return {*} Result of executed code.
+	 */
+
+	run(code) {
+		let script = this.compile(code);
+		return this.execute(script);
 	}
 }
 
@@ -146,6 +173,14 @@ class NodeVM extends EventEmitter {
 	constructor(options = {}) {
 		super();
 
+		this.createNewContext(options);
+	}
+
+	/**
+	 * Create a new context, same arguments as constructor
+	 * @param {Object} [options] VM options.
+	 */
+	createNewContext(options = {}) {
 		// defaults
 		this.options = {
 			sandbox: options.sandbox != null ? options.sandbox : null,
@@ -260,20 +295,35 @@ class NodeVM extends EventEmitter {
 	}
 
 	/**
-	 * Run the code in NodeVM.
-	 *
-	 * First time you run this method, code is executed same way like in node's regular `require` - it's executed with `module`, `require`, `exports`, `__dirname`, `__filename` variables and expect result in `module.exports'.
+	 * Compile code and return object, can assist with performance
 	 *
 	 * @param {String} code Code to run.
 	 * @param {String} [filename] Filename that shows up in any stack traces produced from this script.
-	 * @return {*} Result of executed code.
+	 * @returns {vm.Script}
 	 */
-
-	run(code, filename) {
+	compile(code, filename) {
 		if (this.options.compiler !== 'javascript') {
 			code = _compileToJS(code, this.options.compiler);
 		}
 
+		let module = vm.runInContext("({exports: {}})", this._context, {
+			displayErrors: false
+		});
+
+		return new vm.Script(`(function (exports, require, module, __filename, __dirname) { ${code} \n})`, {
+			filename: filename || "vm.js",
+			displayErrors: false
+		});
+	}
+
+	/**
+	 * Executes a compiled script and returns results
+	 *
+	 * @param {vm.Script} script Script to execute
+	 * @param {String} [filename] Filename that shows up in any stack traces produced from this script.
+	 * @returns {*} Result of executed code
+	 */
+	execute(script, filename) {
 		if (filename) {
 			filename = pa.resolve(filename);
 			var dirname = pa.dirname(filename);
@@ -282,16 +332,6 @@ class NodeVM extends EventEmitter {
 			filename = null;
 			var dirname = null;
 		}
-
-		let module = vm.runInContext("({exports: {}})", this._context, {
-			displayErrors: false
-		});
-
-		let script = new vm.Script(`(function (exports, require, module, __filename, __dirname) { ${code} \n})`, {
-			filename: filename || "vm.js",
-			displayErrors: false
-		});
-
 		try {
 			let closure = script.runInContext(this._context, {
 				filename: filename || "vm.js",
@@ -308,6 +348,21 @@ class NodeVM extends EventEmitter {
 		} else {
 			return this._internal.Decontextify.value(returned);
 		}
+	}
+
+	/**
+	 * Run the code in NodeVM.
+	 *
+	 * First time you run this method, code is executed same way like in node's regular `require` - it's executed with `module`, `require`, `exports`, `__dirname`, `__filename` variables and expect result in `module.exports'.
+	 *
+	 * @param {String} code Code to run.
+	 * @param {String} [filename] Filename that shows up in any stack traces produced from this script.
+	 * @return {*} Result of executed code.
+	 */
+
+	run(code, filename) {
+		let script = this.compile(code, filename);
+		return this.execute(script, filename);
 	}
 
 	/**

--- a/lib/main.js
+++ b/lib/main.js
@@ -309,10 +309,6 @@ class NodeVM extends EventEmitter {
 			code = _compileToJS(code, this.options.compiler);
 		}
 
-		let module = vm.runInContext("({exports: {}})", this._context, {
-			displayErrors: false
-		});
-
 		return new vm.Script(`(function (exports, require, module, __filename, __dirname) { ${code} \n})`, {
 			filename: filename || "vm.js",
 			displayErrors: false
@@ -336,18 +332,22 @@ class NodeVM extends EventEmitter {
 			var dirname = null;
 		}
 		try {
+			var mod = vm.runInContext("({exports: {}})", this._context, {
+				displayErrors: false
+			});
+
 			let closure = script.runInContext(this._context, {
 				filename: filename || "vm.js",
 				displayErrors: false
 			});
 
-			var returned = closure.call(this._context, module.exports, this._prepareRequire(dirname), module, filename, dirname);
+			var returned = closure.call(this._context, mod.exports, this._prepareRequire(dirname), mod, filename, dirname);
 		} catch (e) {
 			throw this._internal.Decontextify.value(e);
 		}
 
 		if (this.options.wrapper === 'commonjs') {
-			return this._internal.Decontextify.value(module.exports);
+			return this._internal.Decontextify.value(mod.exports);
 		} else {
 			return this._internal.Decontextify.value(returned);
 		}


### PR DESCRIPTION
I'll be testing this more thoroughly soon, but noticed this issue and had a need for this, so went ahead and wrote up this pull request.

The idea is the API as it exists now still functions the same as before according to docs, but if you wish you can now also do this:

```
let script =  vm.script(code, filename);
vm.execute(script, filename);//executed with options passed to constructor
vm.createNewContext(newOptions);
vm.execute(script, filename); //executed with new options
```