### PR TITLE
Support whitelisting modules inside a VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Unlike `VM`, `NodeVM` lets you require modules same way like in regular Node's c
 * `sandbox` - VM's global object.
 * `compiler` - `javascript` (default) or `coffeescript` or custom compiler function. The library expects you to have coffee-script pre-installed if the compiler is set to `coffeescript`.
 * `require` - `true` or object to enable `require` method (default: `false`).
-* `require.external` - `true` to enable `require` of external modules (default: `false`).
+* `require.external` - `true` or an array of allowed external modules (default: `false`).
 * `require.builtin` - Array of allowed builtin modules (default: none).
 * `require.root` - Restricted path where local modules can be required (default: every path).
 * `require.mock` - Collection of mock modules (both external or builtin).

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -207,6 +207,11 @@ return ((vm, host) => {
 
 				if (!current_dirname) throw new VMError("You must specify script path to load relative modules.", "ENOPATH");
 
+				if(Array.isArray(vm.options.require.external)) {
+					const isWhitelisted = vm.options.require.external.indexOf(modulename) !== -1
+					if (!isWhitelisted) throw new VMError(`The module '${modulename}' is not whitelisted in VM.`, "EDENIED");
+				}
+
 				const paths = current_dirname.split(pa.sep);
 
 				while (paths.length) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -517,6 +517,46 @@ describe('modules', () => {
 		vm.run("require('foobar')", __filename);
 	})
 
+	it('can require a module inside the vm', () => {
+		let vm = new NodeVM({
+			require: {
+				external: true
+			}
+		})
+
+		vm.run("require('mocha')", __filename);
+	})
+
+	it('can deny requiring modules inside the vm', () => {
+		let vm = new NodeVM({
+			require: {
+				external: false
+			}
+		})
+
+		assert.throws(() => vm.run("require('mocha')", __filename), err => {
+			assert.equal(err.name, 'VMError');
+			assert.equal(err.message, 'Access denied to require \'mocha\'');
+			return true;
+		})
+	})
+
+	it('can whitelist modules inside the vm', () => {
+		let vm = new NodeVM({
+			require: {
+				external: ['mocha']
+			}
+		})
+
+		assert.ok(vm.run("require('mocha')", __filename))
+		assert.throws(() => vm.run("require('unknown')", __filename), err => {
+			assert.equal(err.name, 'VMError');
+			assert.equal(err.message, "The module 'unknown' is not whitelisted in VM.");
+			return true;
+		})
+	})
+
+
 	it('arguments attack', () => {
 		let vm = new NodeVM;
 


### PR DESCRIPTION
Hey there - great library, I've started looking at using it [inside Danger](http://danger.systems/js/) - https://github.com/danger/danger-js/pull/328 as a replacement for jest's internals. So far it's getting there, and I wanted to at least understand the dependency. 

Looks 👍 - I'd like the ability to say that only certain external modules can be used inside a sandbox, so I extended the existing rule to also support an array similar to the `builtin` option.

I noticed that one of the tests failed on master, it's called `error` - which I wondered if it because I was using node v8.2.1. I left it red, so if this build fails it's probably that.