### PR TITLE
Allow a custom compiler to receive the filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Unlike `VM`, `NodeVM` lets you require modules same way like in regular Node's c
 
 * `console` - `inherit` to enable console, `redirect` to redirect to events, `off` to disable console (default: `inherit`).
 * `sandbox` - VM's global object.
-* `compiler` - `javascript` (default) or `coffeescript` or custom compiler function. The library expects you to have coffee-script pre-installed if the compiler is set to `coffeescript`.
+* `compiler` - `javascript` (default) or `coffeescript` or custom compiler function (which receives the code, and it's filepath). The library expects you to have coffee-script pre-installed if the compiler is set to `coffeescript`.
 * `require` - `true` or object to enable `require` method (default: `false`).
 * `require.external` - `true` to enable `require` of external modules (default: `false`).
 * `require.builtin` - Array of allowed builtin modules (default: none).

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Unlike `VM`, `NodeVM` lets you require modules same way like in regular Node's c
 * `compiler` - `javascript` (default) or `coffeescript` or custom compiler function (which receives the code, and it's filepath). The library expects you to have coffee-script pre-installed if the compiler is set to `coffeescript`.
 * `require` - `true` or object to enable `require` method (default: `false`).
 * `require.external` - `true` to enable `require` of external modules (default: `false`).
-* `require.builtin` - Array of allowed builtin modules (default: none).
+* `require.builtin` - Array of allowed builtin modules, accepts ["*"] for all (default: none).
 * `require.root` - Restricted path where local modules can be required (default: every path).
 * `require.mock` - Collection of mock modules (both external or builtin).
 * `require.context` - `host` (default) to require modules in host and proxy them to sandbox. `sandbox` to load, compile and require modules in sandbox. Builtin modules except `events` always required in host and proxied to sandbox.

--- a/lib/main.js
+++ b/lib/main.js
@@ -8,8 +8,8 @@ const cf = fs.readFileSync(`${__dirname}/contextify.js`, 'utf8');
 
 const PROTECTED = ['constructor', '__proto__'];
 
-const _compileToJS = function compileToJS(code, compiler) {
-	if ('function' === typeof compiler) return compiler(code);
+const _compileToJS = function compileToJS(code, compiler, filename) {
+	if ('function' === typeof compiler) return compiler(code, filename);
 
 	switch (compiler) {
 		case 'coffeescript':
@@ -396,7 +396,7 @@ class NodeVM extends EventEmitter {
 
 	run(code, filename) {
 		if (this.options.compiler !== 'javascript') {
-			code = _compileToJS(code, this.options.compiler);
+			code = _compileToJS(code, this.options.compiler, filename);
 		}
 
 		if (filename) {

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -47,7 +47,12 @@ return ((vm, host) => {
 			} else {
 				try {
 					// Load module
-					var code = `(function (exports, require, module, __filename, __dirname) { 'use strict'; ${fs.readFileSync(filename, "utf8")} \n});`;
+					var contents = fs.readFileSync(filename, "utf8")
+					if (typeof vm.options.compiler === "function") {
+						contents = vm.options.compiler(contents, filename)
+					}
+
+					var code = `(function (exports, require, module, __filename, __dirname) { 'use strict'; ${contents} \n});`;
 
 					// Precompile script
 					const script = new Script(code, {

--- a/test/tests.js
+++ b/test/tests.js
@@ -463,6 +463,31 @@ describe('modules', () => {
 		assert.equal(vm.run("module.exports = working: true").working, true);
 	})
 
+	it('optionally can run a custom compiler function', () => {
+		var ranCustomCompiler = false
+		const scriptCode = 'var a = 1;'
+		let vm = new NodeVM({
+			compiler: (code) => {
+				ranCustomCompiler = true
+				assert.equal(code, scriptCode)
+			}
+		})
+		vm.run(scriptCode)
+		assert.equal(ranCustomCompiler, true);
+	})
+
+	it('optionally passes a filename to a custom compiler function', () => {
+		var ranCustomCompiler = false
+		let vm = new NodeVM({
+			compiler: (code, filename) => {
+				ranCustomCompiler = true
+				assert.equal(filename, '/a/b/c.js')
+			}
+		})
+		vm.run("module.exports = working: true", '/a/b/c.js')
+		assert.equal(ranCustomCompiler, true);
+	})
+
 	it('disabled require', () => {
 		let vm = new NodeVM;
 


### PR DESCRIPTION
Great job on the compiler infra, I want to be able to add TypeScript support inside my project and realistically I don't think I should be running the compiler on any JS file that it finds. 

So, I've added the ability for the compiler to pass in the filename as a second argument. As this is JS then adding the extra param is not a breaking change. I added a test to cover that just to be certain 👍 