### PR TITLE
Make vm.runInThisContext run inside VM

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -151,6 +151,32 @@ return ((vm, host) => {
 			}
 		}
 
+		if (modulename === 'vm') {
+			try {
+				const script = new Script(`(function (exports, require, module, process) { 'use strict'; ${BUILTIN_MODULES[modulename]} \n});`, {
+					filename: `${modulename}.vm.js`
+				});
+
+				// setup module scope
+				const module = BUILTINS[modulename] = {
+					exports: {},
+					require: _requireBuiltin
+				};
+
+				// run script
+				script.runInContext(global)(module.exports, module.require, module, host.process);
+
+				// runInThisContext from builtins can access global scope outside of NodeVM
+				module.exports.runInThisContext = function(code, option) {
+					return module.exports.runInContext(code, global, option);
+				};
+
+				return Contextify.readonly(module.exports);
+			} catch (e) {
+				throw Contextify.value(e);
+			}
+		}
+
 		return Contextify.readonly(host.require(modulename));
 	};
 


### PR DESCRIPTION
Builtin vm.runInThisContext can access global scope of host.
This change makes runInThisContext run on own context of VM.