### PR TITLE
Make VMScript constructor path parameter optional in d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -115,7 +115,7 @@ export class VM {
  * to any VM (context); rather, it is bound before each run, just for that run.
  */
 export class VMScript {
-  constructor(code: string, path: string);
+  constructor(code: string, path?: string);
   /** Wraps the code */
   wrap(prefix: string, postfix: string): VMScript;
   /** Compiles the code. If called multiple times, the code is only compiled once. */


### PR DESCRIPTION
It's optional in code, so should be the same in the typings.

https://github.com/patriksimek/vm2/blob/788d06f28724b68fc1eaa08c881314c466e9f870/lib/main.js#L53