### PR TITLE
allow to pass some options to internal vm.Script

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -35,7 +35,7 @@ const _compileToJS = function compileToJS(code, compiler, filename) {
 
 /**
  * Class Script
- * 
+ *
  * @class
  */
 
@@ -48,9 +48,10 @@ class VMScript {
 	 * @return {VMScript}
 	 */
 
-	constructor(code, filename) {
+	constructor(code, filename, options) {
 		this.code = code;
 		this.filename = filename || 'vm.js';
+		this.options = options
 	}
 
 	/**
@@ -58,7 +59,7 @@ class VMScript {
 	 *
 	 * @return {VMScript}
 	 */
-	
+
 	wrap(prefix, suffix) {
 		if (this._wrapped) return this;
 		this.code = prefix + this.code + suffix;
@@ -71,15 +72,29 @@ class VMScript {
 	 *
 	 * @return {VMScript}
 	 */
-	
+
 	compile() {
 		if (this._compiled) return this;
-		
-		this._compiled = new vm.Script(this.code, {
+
+		const options = {
 			filename: this.filename,
 			displayErrors: false
-		})
-		
+		};
+
+		if (this.options && this.options.displayErrors != null) {
+			options.displayErrors = this.options.displayErrors
+		}
+
+		if (this.options && this.options.lineOffset != null) {
+			options.lineOffset = this.options.lineOffset
+		}
+
+		if (this.options && this.options.columnOffset != null) {
+			options.columnOffset = this.options.columnOffset
+		}
+
+		this._compiled = new vm.Script(this.code, options)
+
 		return this;
 	}
 }
@@ -205,7 +220,7 @@ class VM extends EventEmitter {
 		if (this.options.compiler !== 'javascript') {
 			code = _compileToJS(code, this.options.compiler);
 		}
-		
+
 		const script = code instanceof VMScript ? code : new VMScript(code);
 
 		try {
@@ -222,7 +237,7 @@ class VM extends EventEmitter {
 
 /**
  * Class NodeVM.
- * 
+ *
  * @class
  * @extends {EventEmitter}
  * @property {Object} module Pointer to main module.
@@ -414,7 +429,7 @@ class NodeVM extends EventEmitter {
 		const module = vm.runInContext("({exports: {}})", this._context, {
 			displayErrors: false
 		});
-		
+
 		const script = code instanceof VMScript ? code : new VMScript(code, filename);
 		script.wrap('(function (exports, require, module, __filename, __dirname) { ', ' \n})');
 


### PR DESCRIPTION
hi! first of all thanks for great module. this PR is about allowing to pass some options to the internal [vm.Script](https://nodejs.org/dist/latest-v8.x/docs/api/vm.html#vm_class_vm_script). 

the option that i was needing the more is the `displayErrors`, i needed to set it to true in order to provide nice source code highlighting in errors when some user script fails to compile. 

this PR don't change the default behaviour of vm2, `displayErrors` is still in false in normal usage, this PR allows passing options in advanced scenarios when we know what we are doing.

sample usage:

```js
const { VM, VMScript } = require('vm2');
const vm = new VM();

vm.run(new VMScript(`
  // functions provided by some user input,
  // with this PR, if there is some syntax errors while
  // compiling the user script, the error will contain nice source code highlighting
  function beforeRender() {} 

  function afterRender () {}
`, 'user-input.js', {
  displayErrors: true
}));
```