### PR TITLE
"missing" EventEmitter props NodeVM inherits

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import {EventEmitter} from 'events';
+
 /**
  *  Require options for a VM
  */
@@ -63,7 +65,7 @@ export interface NodeVMOptions extends VMOptions {
 /**
  * A VM with behavior more similar to running inside Node.
  */
-export class NodeVM {
+export class NodeVM extends EventEmitter {
   constructor(options?: NodeVMOptions);
   /** Runs the code */
   run(js: string, path: string): any;


### PR DESCRIPTION
NodeVM extends EventEmitter, so has .on and .off methods.

If you do something like

    const vm = new NodeVM({...});
    vm.on(ev, handler);

TS will complain that NodeVM has no "on" property because the type definitions for vm2 lacks any indication that NodeVM inherits from EventEmitter. That's what this PR fixes.