### PR TITLE
Add arguments to process.nextTick proxy.

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -347,13 +347,15 @@ return ((vm, host) => {
 		env: {},
 		pid: host.process.pid,
 		features: Contextify.readonly(host.process.features),
-		nextTick(callback) {
+		nextTick(callback, ...args) {
 				if (typeof callback !== 'function') {
 					throw new Error('Callback must be a function.');
 				};
 
 				try {
-					return host.process.nextTick(Decontextify.value(callback));
+					return host.process.nextTick(Decontextify.value(function() {
+						callback.apply(null, args)
+					}));
 				} catch (e) {
 					throw Contextify.value(e);
 				}


### PR DESCRIPTION
Firstly, great work!

I've patched a minor inconsistency with `nextTick` not taking any arguments. I did it in the same manor as `setImmediate` and `setInterval` was done.

Hopefully it's of use and I've understood the internals correctly!