### PR TITLE
Fix for issue with JS Date object

### DIFF
--- a/lib/contextify.js
+++ b/lib/contextify.js
@@ -426,7 +426,7 @@ const Contextify = {
 				} else if (value instanceof host.Number)         { return host.Number(value);
 				} else if (value instanceof host.String)         { return host.String(value);
 				} else if (value instanceof host.Boolean)        { return host.Boolean(value);
-				} else if (value instanceof host.Date)           { return host.Date(value);
+				} else if (value instanceof host.Date)           { return Contextify.instance(value, Date, deepTraps, flags);
 				} else if (value instanceof host.RangeError)     { return Contextify.instance(value, RangeError, deepTraps, flags);
 				} else if (value instanceof host.ReferenceError) { return Contextify.instance(value, ReferenceError, deepTraps, flags);
 				} else if (value instanceof host.SyntaxError)    { return Contextify.instance(value, SyntaxError, deepTraps, flags);

--- a/lib/contextify.js
+++ b/lib/contextify.js
@@ -216,7 +216,7 @@ const Decontextify = {
 				} else if (value instanceof Number)         { return host.Number(value);
 				} else if (value instanceof String)         { return host.String(value);
 				} else if (value instanceof Boolean)        { return host.Boolean(value);
-				} else if (value instanceof Date)           { return Decontextify.instance(value, host.Date, deepTraps, flags);
+				} else if (value instanceof Date)           { return new host.Date(value);
 				} else if (value instanceof RangeError)     { return Decontextify.instance(value, host.RangeError, deepTraps, flags);
 				} else if (value instanceof ReferenceError) { return Decontextify.instance(value, host.ReferenceError, deepTraps, flags);
 				} else if (value instanceof SyntaxError)    { return Decontextify.instance(value, host.SyntaxError, deepTraps, flags);
@@ -426,7 +426,7 @@ const Contextify = {
 				} else if (value instanceof host.Number)         { return host.Number(value);
 				} else if (value instanceof host.String)         { return host.String(value);
 				} else if (value instanceof host.Boolean)        { return host.Boolean(value);
-				} else if (value instanceof host.Date)           { return Contextify.instance(value, Date, deepTraps, flags);
+				} else if (value instanceof host.Date)           { return new host.Date(value);
 				} else if (value instanceof host.RangeError)     { return Contextify.instance(value, RangeError, deepTraps, flags);
 				} else if (value instanceof host.ReferenceError) { return Contextify.instance(value, ReferenceError, deepTraps, flags);
 				} else if (value instanceof host.SyntaxError)    { return Contextify.instance(value, SyntaxError, deepTraps, flags);

--- a/lib/contextify.js
+++ b/lib/contextify.js
@@ -426,7 +426,7 @@ const Contextify = {
 				} else if (value instanceof host.Number)         { return host.Number(value);
 				} else if (value instanceof host.String)         { return host.String(value);
 				} else if (value instanceof host.Boolean)        { return host.Boolean(value);
-				} else if (value instanceof host.Date)           { return new host.Date(value);
+				} else if (value instanceof host.Date)           { return host.Date(value);
 				} else if (value instanceof host.RangeError)     { return Contextify.instance(value, RangeError, deepTraps, flags);
 				} else if (value instanceof host.ReferenceError) { return Contextify.instance(value, ReferenceError, deepTraps, flags);
 				} else if (value instanceof host.SyntaxError)    { return Contextify.instance(value, SyntaxError, deepTraps, flags);


### PR DESCRIPTION
Hi,

We are using the vm2 sandbox, but we experience some problems executing scripts that contain dates.  The vm2 sandbox transforms dates into number, so the vm2 sandbox changes the default behaviour of the JS Date object. For example when we execute a script with the following code in the vm2 sandbox: 
`console.log(new Date('6-7-2018'));` 
It returns:
`[Number: 1528329600000]` instead of `2018-06-07T00:00:00.000Z`

In most of the cases this isn't a problem, because date functions (like toISOString) still work. But we combine the vm2 package with the momentJS library, and the momentJS library can't handle a number as input. 

With the changes of this PR  the Decontextify and Contextify class for instances of a Date objects will return a Date instead of a Number.

With the changes of this PR, dates are not transformed into numbers, so when we execute a script with the following code in the vm2 sandbox: 
`console.log(new Date('6-7-2018'));` 
It returns:
`2018-06-07T00:00:00.000Z`

Are you able to reproduce this issue?, and can you create a fix for this issue or approve this PR?