### PR TITLE
Allow custom resolver & multiple root folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Unlike `VM`, `NodeVM` lets you require modules same way like in regular Node's c
 * `require.mock` - Collection of mock modules (both external or builtin).
 * `require.context` - `host` (default) to require modules in host and proxy them to sandbox. `sandbox` to load, compile and require modules in sandbox. Builtin modules except `events` always required in host and proxied to sandbox.
 * `require.import` - Array of modules to be loaded into NodeVM on start.
+* `require.resolve` - An additional lookup function in case a module wasn't found in one of the traditional node lookup paths.
 * `nesting` - `true` to enable VMs nesting (default: `false`).
 * `wrapper` - `commonjs` (default) to wrap script into CommonJS wrapper, `none` to retrieve value returned by the script.
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Unlike `VM`, `NodeVM` lets you require modules same way like in regular Node's c
 * `require` - `true` or object to enable `require` method (default: `false`).
 * `require.external` - `true` or an array of allowed external modules (default: `false`).
 * `require.builtin` - Array of allowed builtin modules, accepts ["*"] for all (default: none).
-* `require.root` - Restricted path where local modules can be required (default: every path).
+* `require.root` - Restricted path(s) where local modules can be required (default: every path).
 * `require.mock` - Collection of mock modules (both external or builtin).
 * `require.context` - `host` (default) to require modules in host and proxy them to sandbox. `sandbox` to load, compile and require modules in sandbox. Builtin modules except `events` always required in host and proxied to sandbox.
 * `require.import` - Array of modules to be loaded into NodeVM on start.

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,8 +7,8 @@ export interface VMRequire {
   /** Array of allowed builtin modules, accepts ["*"] for all (default: none) */
   builtin?: string[];
   /*
-   * `host` (default) to require modules in host and proxy them to sandbox. `sandbox` to load, compile and 
-   * require modules in sandbox. Builtin modules except `events` always required in host and proxied to sandbox 
+   * `host` (default) to require modules in host and proxy them to sandbox. `sandbox` to load, compile and
+   * require modules in sandbox. Builtin modules except `events` always required in host and proxied to sandbox
    */
   context?: "host" | "sandbox";
   /** `true` or an array of allowed external modules (default: `false`) */
@@ -19,6 +19,8 @@ export interface VMRequire {
   root?: string;
   /** Collection of mock modules (both external or builtin). */
   mock?: any;
+  /* An additional lookup function in case a module wasn't found in one of the traditional node lookup paths. */
+  resolve?: (moduleName: String) => String;
 }
 
 /**
@@ -31,22 +33,22 @@ type CompilerFunction = (code: string, filename: string) => string;
  *  Options for creating a VM
  */
 export interface VMOptions {
-  /** 
+  /**
    * `javascript` (default) or `coffeescript` or custom compiler function (which receives the code, and it's filepath).
-   *  The library expects you to have coffee-script pre-installed if the compiler is set to `coffeescript`. 
+   *  The library expects you to have coffee-script pre-installed if the compiler is set to `coffeescript`.
    */
   compiler?: "javascript" | "coffeescript" | CompilerFunction;
   /** VM's global object. */
   sandbox?: any;
   /**
-   * Script timeout in milliseconds.  Timeout is only effective on code you run through `run`. 
+   * Script timeout in milliseconds.  Timeout is only effective on code you run through `run`.
    * Timeout is NOT effective on any method returned by VM.
    */
   timeout?: number;
 }
 
 /**
- *  Options for creating a NodeVM 
+ *  Options for creating a NodeVM
  */
 export interface NodeVMOptions extends VMOptions {
   /** `inherit` to enable console, `redirect` to redirect to events, `off` to disable console (default: `inherit`). */
@@ -56,7 +58,7 @@ export interface NodeVMOptions extends VMOptions {
   /** `true` to enable VMs nesting (default: `false`). */
   nesting?: boolean;
   /** `commonjs` (default) to wrap script into CommonJS wrapper, `none` to retrieve value returned by the script. */
-  wrapper?: "commonjs" | "none";  
+  wrapper?: "commonjs" | "none";
   /** File extensions that the internal module resolver should accept. */
   sourceExtensions?: string[]
 }
@@ -77,7 +79,7 @@ export class NodeVM extends EventEmitter {
   protect(object: any, name: string): any;
   /** Require a module in VM and return it's exports. */
   require(module: string): any;
-  
+
    /**
    * Create NodeVM and run code inside it.
    *
@@ -97,8 +99,8 @@ export class NodeVM extends EventEmitter {
 }
 
 /**
- * VM is a simple sandbox, without `require` feature, to synchronously run an untrusted code. 
- * Only JavaScript built-in objects + Buffer are available. Scheduling functions 
+ * VM is a simple sandbox, without `require` feature, to synchronously run an untrusted code.
+ * Only JavaScript built-in objects + Buffer are available. Scheduling functions
  * (`setInterval`, `setTimeout` and `setImmediate`) are not available by default.
  */
 export class VM {
@@ -114,7 +116,7 @@ export class VM {
 }
 
 /**
- * You can increase performance by using pre-compiled scripts. 
+ * You can increase performance by using pre-compiled scripts.
  * The pre-compiled VMScript can be run later multiple times. It is important to note that the code is not bound
  * to any VM (context); rather, it is bound before each run, just for that run.
  */

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,8 +15,8 @@ export interface VMRequire {
   external?: boolean | string[];
   /** Array of modules to be loaded into NodeVM on start. */
   import?: string[];
-  /** Restricted path where local modules can be required (default: every path). */
-  root?: string;
+  /** Restricted path(s) where local modules can be required (default: every path). */
+  root?: string | string[];
   /** Collection of mock modules (both external or builtin). */
   mock?: any;
   /* An additional lookup function in case a module wasn't found in one of the traditional node lookup paths. */

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ export interface VMRequire {
   /** Collection of mock modules (both external or builtin). */
   mock?: any;
   /* An additional lookup function in case a module wasn't found in one of the traditional node lookup paths. */
-  resolve?: (moduleName: String) => String;
+  resolve?: (moduleName: String, parentDirname: String) => String;
 }
 
 /**

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -251,6 +251,9 @@ return ((vm, host) => {
 				}
 			}
 
+			if (!filename && vm.options.require.resolve) {
+				filename = _resolveFilename(vm.options.require.resolve(moduleName));
+			}
 			if (!filename) throw new VMError(`Cannot find module '${moduleName}'`, 'ENOTFOUND');
 
 			// return cache whenever possible

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -263,8 +263,10 @@ return ((vm, host) => {
 			const extname = pa.extname(filename);
 
 			if (vm.options.require.root) {
-				const requiredPath = pa.resolve(vm.options.require.root);
-				if (dirname.indexOf(requiredPath) !== 0) {
+				const rootPaths = Array.isArray(vm.options.require.root) ? vm.options.require.root : [vm.options.require.root];
+				const allowedModule = rootPaths.some(path => dirname.startsWith(pa.resolve(path)));
+
+				if (!allowedModule) {
 					throw new VMError(`Module '${moduleName}' is not allowed to be required. The path is outside the border!`, 'EDENIED');
 				}
 			}

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -252,7 +252,7 @@ return ((vm, host) => {
 			}
 
 			if (!filename && vm.options.require.resolve) {
-				filename = _resolveFilename(vm.options.require.resolve(moduleName));
+				filename = _resolveFilename(vm.options.require.resolve(moduleName, currentDirname));
 			}
 			if (!filename) throw new VMError(`Cannot find module '${moduleName}'`, 'ENOTFOUND');
 

--- a/test/additional-modules/my-module/index.js
+++ b/test/additional-modules/my-module/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/nodevm.js
+++ b/test/nodevm.js
@@ -4,6 +4,7 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 const assert = require('assert');
 const {NodeVM, VMScript} = require('..');
 
@@ -187,6 +188,17 @@ describe('modules', () => {
 			assert.equal(err.message, "The module 'unknown' is not whitelisted in VM.");
 			return true;
 		});
+	});
+
+	it('can resolve paths based on a custom resolver', () => {
+		const vm = new NodeVM({
+			require: {
+				external: ['my-module'],
+				resolve: moduleName => path.resolve(__dirname, 'additional-modules', moduleName)
+			}
+		});
+
+		assert.ok(vm.run("require('my-module')", __filename));
 	});
 
 

--- a/test/nodevm.js
+++ b/test/nodevm.js
@@ -201,6 +201,20 @@ describe('modules', () => {
 		assert.ok(vm.run("require('my-module')", __filename));
 	});
 
+	it('allows for multiple root folders', () => {
+		const vm = new NodeVM({
+			require: {
+				external: ['mocha'],
+				root: [
+					path.resolve(__dirname),
+					path.resolve(__dirname, '..', 'node_modules')
+				]
+			}
+		});
+
+		assert.ok(vm.run("require('mocha')", __filename));
+	});
+
 
 	it('arguments attack', () => {
 		let vm = new NodeVM;


### PR DESCRIPTION
hey @patriksimek 

Thanks for this lovely library.
We want to use it for running untrusted code, but in our case, we allow requiring modules from a custom fs location, which are shared among many untrusted code branches.
Therefore, we want those to be resolved by our custom resolver, and allow them to be stored outside the user's root folder.

