### PR TITLE
Allow transitive external dependencies in sandbox context

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ Unlike `VM`, `NodeVM` lets you require modules same way like in regular Node's c
 * `compiler` - `javascript` (default) or `coffeescript` or custom compiler function (which receives the code, and it's filepath). The library expects you to have coffee-script pre-installed if the compiler is set to `coffeescript`.
 * `sourceExtensions` - Array of file extensions to treat as source code (default: `['js']`).
 * `require` - `true` or object to enable `require` method (default: `false`).
-* `require.external` - `true` or an array of allowed external modules (default: `false`).
+* `require.external` - `true`, an array of allowed external modules or an object (default: `false`).
+* `require.external.modules` - Array of allowed external modules.
+* `require.external.transitive` - Boolean which indicates if transitive dependencies of external modules are allowed. (default: `false`).
 * `require.builtin` - Array of allowed builtin modules, accepts ["*"] for all (default: none).
 * `require.root` - Restricted path(s) where local modules can be required (default: every path).
 * `require.mock` - Collection of mock modules (both external or builtin).

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,8 +11,8 @@ export interface VMRequire {
    * require modules in sandbox. Builtin modules except `events` always required in host and proxied to sandbox
    */
   context?: "host" | "sandbox";
-  /** `true` or an array of allowed external modules (default: `false`) */
-  external?: boolean | string[];
+  /** `true`, an array of allowed external modules or an object with external options (default: `false`) */
+  external?: boolean | string[] | { modules: string[], transitive: boolean };
   /** Array of modules to be loaded into NodeVM on start. */
   import?: string[];
   /** Restricted path(s) where local modules can be required (default: every path). */

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -84,6 +84,20 @@ return ((vm, host) => {
 		};
 	}
 
+	const _parseExternalOptions = (options) => {
+		if (Array.isArray(options)) {
+			return {
+				external: options,
+				transitive: false
+			};
+		}
+
+		return {
+			external: options.modules,
+			transitive: options.transitive
+		};
+	};
+
 	/**
 	 * Resolve filename.
 	 */
@@ -176,7 +190,7 @@ return ((vm, host) => {
 	 * Prepare require.
 	 */
 
-	const _prepareRequire = (currentDirname, wasParentExternal = false) => {
+	const _prepareRequire = (currentDirname, parentAllowsTransitive = false) => {
 		const _require = moduleName => {
 			if (vm.options.nesting && moduleName === 'vm2') return {VM: Contextify.readonly(host.VM), NodeVM: Contextify.readonly(host.NodeVM)};
 			if (!vm.options.require) throw new VMError(`Access denied to require '${moduleName}'`, 'EDENIED');
@@ -184,7 +198,7 @@ return ((vm, host) => {
 			if (typeof moduleName !== 'string') throw new VMError(`Invalid module name '${moduleName}'`, 'EINVALIDNAME');
 
 			let filename;
-			let isExternal = false;
+			let allowRequireTransitive = false;
 
 			// Mock?
 
@@ -233,10 +247,15 @@ return ((vm, host) => {
 
 				if (!currentDirname) throw new VMError('You must specify script path to load relative modules.', 'ENOPATH');
 
-				if (Array.isArray(vm.options.require.external)) {
-					const isWhitelisted = vm.options.require.external.indexOf(moduleName) !== -1;
-					if (!isWhitelisted && !wasParentExternal) throw new VMError(`The module '${moduleName}' is not whitelisted in VM.`, 'EDENIED');
-					isExternal = true;
+				if (typeof vm.options.require.external === 'object') {
+					const { external, transitive } = _parseExternalOptions(vm.options.require.external);
+
+					const isWhitelisted = external.indexOf(moduleName) !== -1 || (transitive && parentAllowsTransitive);
+					if (!isWhitelisted) {
+						throw new VMError(`The module '${moduleName}' is not whitelisted in VM.`, 'EDENIED');
+					}
+
+					allowRequireTransitive = true;
 				}
 
 				const paths = currentDirname.split(pa.sep);
@@ -276,7 +295,7 @@ return ((vm, host) => {
 			const module = CACHE[filename] = {
 				filename,
 				exports: {},
-				require: _prepareRequire(dirname, isExternal)
+				require: _prepareRequire(dirname, allowRequireTransitive)
 			};
 
 			// lookup extensions

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -176,7 +176,7 @@ return ((vm, host) => {
 	 * Prepare require.
 	 */
 
-	const _prepareRequire = currentDirname => {
+	const _prepareRequire = (currentDirname, wasParentExternal = false) => {
 		const _require = moduleName => {
 			if (vm.options.nesting && moduleName === 'vm2') return {VM: Contextify.readonly(host.VM), NodeVM: Contextify.readonly(host.NodeVM)};
 			if (!vm.options.require) throw new VMError(`Access denied to require '${moduleName}'`, 'EDENIED');
@@ -184,6 +184,7 @@ return ((vm, host) => {
 			if (typeof moduleName !== 'string') throw new VMError(`Invalid module name '${moduleName}'`, 'EINVALIDNAME');
 
 			let filename;
+			let isExternal = false;
 
 			// Mock?
 
@@ -234,7 +235,8 @@ return ((vm, host) => {
 
 				if (Array.isArray(vm.options.require.external)) {
 					const isWhitelisted = vm.options.require.external.indexOf(moduleName) !== -1;
-					if (!isWhitelisted) throw new VMError(`The module '${moduleName}' is not whitelisted in VM.`, 'EDENIED');
+					if (!isWhitelisted && !wasParentExternal) throw new VMError(`The module '${moduleName}' is not whitelisted in VM.`, 'EDENIED');
+					isExternal = true;
 				}
 
 				const paths = currentDirname.split(pa.sep);
@@ -274,7 +276,7 @@ return ((vm, host) => {
 			const module = CACHE[filename] = {
 				filename,
 				exports: {},
-				require: _prepareRequire(dirname)
+				require: _prepareRequire(dirname, isExternal)
 			};
 
 			// lookup extensions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vm2",
-  "version": "3.6.11",
+  "version": "3.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/node_modules/module1/index.js
+++ b/test/node_modules/module1/index.js
@@ -1,0 +1,1 @@
+module.exports = require('module2');

--- a/test/node_modules/module2/index.js
+++ b/test/node_modules/module2/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/nodevm.js
+++ b/test/nodevm.js
@@ -190,6 +190,17 @@ describe('modules', () => {
 		});
 	});
 
+	it('allows transitive external dependencies in sandbox context', () => {
+		const vm = new NodeVM({
+			require: {
+				external: ['module1'],
+				context: 'sandbox'
+			}
+		});
+
+		assert.ok(vm.run("require('module1')", __filename));
+	});
+
 	it('can resolve paths based on a custom resolver', () => {
 		const vm = new NodeVM({
 			require: {

--- a/test/nodevm.js
+++ b/test/nodevm.js
@@ -190,10 +190,13 @@ describe('modules', () => {
 		});
 	});
 
-	it('allows transitive external dependencies in sandbox context', () => {
+	it('allows specific transitive external dependencies in sandbox context', () => {
 		const vm = new NodeVM({
 			require: {
-				external: ['module1'],
+				external: {
+					modules: ['module1'],
+					transitive: true
+				},
 				context: 'sandbox'
 			}
 		});


### PR DESCRIPTION
Hey @patriksimek 

thanks for your quick responses.
I've encountered a case where I want to allow a custom module. However, this custom module uses other modules. This PR allows to load the entire dependency tree while only whitelisting the top-level module (and still using `require.context === 'sandbox'`).

WDYT about it? should it be configurable?
Didn't want to add another require option, it didn't feel right
