### PR TITLE
Handle errors thrown in async functions

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -422,6 +422,10 @@ return ((vm, host) => {
 		return p;
 	};
 	global.Promise.prototype = host.Promise.prototype;
+	global.Promise.all = host.Promise.all;
+	global.Promise.race = host.Promise.race;
+	global.Promise.reject = host.Promise.reject;
+	global.Promise.resolve = host.Promise.resolve;
 
 	global.process = {
 		argv: [],

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -333,7 +333,11 @@ return ((vm, host) => {
 
 	global.setTimeout = (callback, delay, ...args) => {
 		const tmr = host.setTimeout(Decontextify.value(() => {
-			callback(...args);
+			try {
+				callback(...args);
+			} catch (err) {
+				vm.emit('uncaughtException', err);
+			}
 		}), Decontextify.value(delay));
 
 		const local = {
@@ -347,7 +351,11 @@ return ((vm, host) => {
 
 	global.setInterval = (callback, interval, ...args) => {
 		const tmr = host.setInterval(Decontextify.value(() => {
-			callback(...args);
+			try {
+				callback(...args);
+			} catch (err) {
+				vm.emit('uncaughtException', err);
+			}
 		}), Decontextify.value(interval));
 
 		const local = {
@@ -361,7 +369,11 @@ return ((vm, host) => {
 
 	global.setImmediate = (callback, ...args) => {
 		const tmr = host.setImmediate(Decontextify.value(() => {
-			callback(...args);
+			try {
+				callback(...args);
+			} catch (err) {
+				vm.emit('uncaughtException', err);
+			}
 		}));
 
 		const local = {
@@ -405,7 +417,11 @@ return ((vm, host) => {
 
 			try {
 				return host.process.nextTick(Decontextify.value(() => {
-					callback(...args);
+					try {
+						callback(...args);
+					} catch (err) {
+						vm.emit('uncaughtException', err);
+					}
 				}));
 			} catch (e) {
 				throw Contextify.value(e);

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -400,6 +400,29 @@ return ((vm, host) => {
 		return null;
 	};
 
+	global.Promise = function _Promise(fn) {
+		const wrapFn = (resolve, reject) => {
+			const _reject = reason => {
+				try {
+					reject(reason);
+				} catch (err) {
+					vm.emit('unhandledRejection', err);
+				}
+			};
+			try {
+				fn(resolve, _reject);
+			} catch (err) {
+				vm.emit('unhandledRejection', err);
+			}
+		};
+		const p = new host.Promise(wrapFn);
+		// prevents unhandledRejection errors from propagating,
+		// but we don't know if it is ever properly handled or not
+		p.catch(err => vm.emit('promiseRejected', err, p));
+		return p;
+	};
+	global.Promise.prototype = host.Promise.prototype;
+
 	global.process = {
 		argv: [],
 		title: host.process.title,

--- a/test/nodevm.js
+++ b/test/nodevm.js
@@ -39,6 +39,14 @@ describe('NodeVM', () => {
 		assert.equal(vm.run("module.exports = console.log.constructor('return (function(){return this})().isVM')()"), true);
 	});
 
+	it('async errors', done => {
+		vm.run('setTimeout(function() { throw new Error("fail"); })');
+		vm.on('uncaughtException', err => {
+			assert.equal(err.message, 'fail');
+			done();
+		});
+	});
+
 	it.skip('timeout (not supported by Node\'s VM)', () => {
 		assert.throws(() => new NodeVM({
 			timeout: 10


### PR DESCRIPTION
If a callback passed to setTimeout (and other timer functions) throws an error, the error propogates up through the host node process, potentially crashing it unless process.on('uncaughtException') is used.

Wrap all callback functions passed to the various host timer functions in a try/catch, so errors are handled and emitted as events on the vm.