### PR TITLE
Remove duplicate option

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -37,7 +37,7 @@ const _compileToJS = function compileToJS(code, compiler, filename) {
 
 /**
  * Class Script
- * 
+ *
  * @class
  */
 
@@ -228,7 +228,7 @@ class VM extends EventEmitter {
 
 /**
  * Class NodeVM.
- * 
+ *
  * @class
  * @extends {EventEmitter}
  * @property {Object} module Pointer to main module.
@@ -255,7 +255,6 @@ class NodeVM extends EventEmitter {
 			compiler: options.compiler || 'javascript',
 			eval: options.eval === false ? false : true,
 			wasm: options.wasm === false ? false : true,
-			require: options.require || false,
 			nesting: options.nesting || false,
 			wrapper: options.wrapper || 'commonjs',
 			sourceExtensions: options.sourceExtensions || ['js']


### PR DESCRIPTION
While skimming through the code I noticed that `require` option for NodeVM class was being assigned twice.