### PR TITLE
Implement custom error handling

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -109,7 +109,8 @@ class VM extends EventEmitter {
 			sandbox: options.sandbox,
 			compiler: options.compiler || 'javascript',
 			eval: options.eval === false ? false : true,
-			wasm: options.wasm === false ? false : true
+			wasm: options.wasm === false ? false : true,
+			prettyErrors: options.prettyErrors === false ? false : true
 		};
 
 		const host = {
@@ -215,12 +216,68 @@ class VM extends EventEmitter {
 		const script = code instanceof VMScript ? code : new VMScript(code);
 		script.compile();
 
+		let errorHandler;
+		if (this.options.prettyErrors) {
+			errorHandler = function(e) {
+				// Handler for non-Error values
+				if ((typeof e != "object") || !("stack" in e)) {
+					// Do not remove the comment below! It is what users will see.
+					throw new Error(e); // A vm2 script threw a value, and we couldn't fetch a stack trace
+				}
+				// Handler for non-vm2 errors
+				if (!e.stack.includes("/node_modules/vm2/")) {
+					console.log(e);
+					return;
+				}
+				const lines = e.stack.split("\n")
+				const header = lines[0]; // eg. "TypeError: cannot..."
+				const topFrame = lines[1];
+				const [_, filename, line, position] = topFrame.match(/^ +at .+ \((.+):(\d+):(\d+)\)/);
+				const offendingLine = script.code.split("\n")[line-1];
+				let positionString = "";
+				// Tabs count as 1 for `position` purposes, but they take >1 column on most terminals.
+				// This piece of code fixes that.
+				const tabs = offendingLine.match(/^(\t*)/)[1];
+				for (let i = 0; i < tabs.length; i++)
+					positionString += "\t";
+				for (let i = tabs.length; i < position; i++)
+					positionString += " ";
+				positionString += "^";
+				const oldStack = lines.slice(1);
+				const newStack = [];
+				for (const line of oldStack) {
+					// Discard frames from internal code
+					if (line.includes("internal/modules/cjs/loader.js"))
+						continue;
+					if (line.includes("/node_modules/vm2/"))
+						continue;
+					if (line.includes("at Script.runInContext"))
+						continue;
+					// Replace the default filename with the user-provided one
+					const patchedLine = line.replace("(vm.js:", "(" + script.filename + ":");
+					newStack.push(patchedLine);
+				}
+				console.log(filename + ":" + line);
+				console.log(offendingLine);
+				console.log(positionString);
+				console.log("");
+				console.log(header);
+				console.log(newStack.join("\n"));
+			}
+			// Note the ".once": the handler will be removed automatically after an exception occurs
+			// However, we must still remove it manually if no exception occurs
+			process.once("uncaughtException", errorHandler);
+		}
+
 		try {
-			return this._internal.Decontextify.value(script._compiled.runInContext(this._context, {
+			const ret = this._internal.Decontextify.value(script._compiled.runInContext(this._context, {
 				filename: script.filename,
 				displayErrors: false,
 				timeout: this.options.timeout
 			}));
+			if (this.options.prettyErrors)
+				process.removeListener("uncaughtException", errorHandler);
+			return ret;
 		} catch (e) {
 			throw this._internal.Decontextify.value(e);
 		}

--- a/lib/main.js
+++ b/lib/main.js
@@ -222,7 +222,7 @@ class VM extends EventEmitter {
 				// Handler for non-Error values
 				if ((typeof e != "object") || !("stack" in e)) {
 					// Do not remove the comment below! It is what users will see.
-					throw new Error(e); // A vm2 script threw a value, and we couldn't fetch a stack trace
+					throw e; // A vm2 script threw a value, and we couldn't fetch a stack trace
 				}
 				// Handler for non-vm2 errors
 				if (!e.stack.includes("/node_modules/vm2/")) {


### PR DESCRIPTION
As discussed in #87. Produces stack traces that look the same as "native ones", with vm2 frames stripped. Controlled by the `prettyErrors` option for VM, true by default.

**With no pretty errors**

```
/tmp/vm2/node_modules/vm2/lib/main.js:281
                        throw this._internal.Decontextify.value(e);
                        ^
TypeError: Cannot read property 'f' of null
    at f (vm.js:2:7)
    at vm.js:4:1
    at Script.runInContext (vm.js:135:20)
    at VM.run (/tmp/vm2/node_modules/vm2/lib/main.js:272:67)
    at f (/tmp/vm2/index.js:12:5)
    at Object.<anonymous> (/tmp/vm2/index.js:15:1)
    at Module._compile (internal/modules/cjs/loader.js:816:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:827:10)
    at Module.load (internal/modules/cjs/loader.js:685:32)
    at Function.Module._load (internal/modules/cjs/loader.js:620:12)
```

**With pretty errors**

```
vm.js:2
        null.f();
              ^

TypeError: Cannot read property 'f' of null
    at f (vm.js:2:7)
    at vm.js:4:1
    at f (/tmp/vm2/index.js:12:5)
    at Object.<anonymous> (/tmp/vm2/index.js:15:1)```