### PR TITLE
Double wrap Objects

### DIFF
--- a/lib/contextify.js
+++ b/lib/contextify.js
@@ -87,9 +87,9 @@ function throwCallerCalleeArgumentsAccess(key) {
 /*
  * Proxy Helper
  * 
- * Here we track Proxy creations so that we know for every proxy in the VM the
- * target. If the Proxy is given to decontextify we are going to lookup
- * the target and unsing this non proxy as target for the decontextify proxy.
+ * Here we track proxy creations so that we know for every proxy in the VM the
+ * target. If the proxy is given to decontextify we are going to lookup
+ * the target and using this non proxy as target for the decontextify proxy.
  * 
  */
 
@@ -145,6 +145,130 @@ Proxy = ((ProxyFunc) => {
 	};
 	return new host.Proxy(ProxyFunc, ProxyHandler);
 })(Proxy);
+
+/*
+ * Shared proxy handler for inspect proxy.
+ * This is needed since node's inspect method used in console.log
+ * will strip one proxy layer away. The second layer will use this
+ * handler.
+ */
+
+const INSPECT_PROXY_HANDLER = host.Object.create(null);
+
+INSPECT_PROXY_HANDLER.apply = (target, context, args) => {
+	context = Contextify.value(context);
+
+	// Set context of all arguments to vm's context.
+	args = Contextify.arguments(args);
+
+	try {
+		return Decontextify.value(target.apply(context, args));
+	} catch (e) {
+		throw Decontextify.value(e);
+	}
+};
+INSPECT_PROXY_HANDLER.construct = (target, args, newTarget) => {
+	throw new host.VMError('Inspect tried to create new object');
+};
+INSPECT_PROXY_HANDLER.get = (target, key, receiver) => {
+	try {
+		return Decontextify.value(target[key]);
+	} catch (e) {
+		throw Decontextify.value(e);
+	}
+};
+INSPECT_PROXY_HANDLER.set = (target, key, value, receiver) => {
+	// Inspect should not set properties
+	return false;
+};
+INSPECT_PROXY_HANDLER.getOwnPropertyDescriptor = (target, prop) => {
+	let def;
+
+	try {
+		def = host.Object.getOwnPropertyDescriptor(target, prop);
+	} catch (e) {
+		throw Decontextify.value(e);
+	}
+
+	// Following code prevents V8 to throw
+	// TypeError: 'getOwnPropertyDescriptor' on proxy: trap reported non-configurability for property '<prop>'
+	// which is either non-existant or configurable in the proxy target
+
+	if (!def) {
+		return undefined;
+	} else if (def.get || def.set) {
+		return {
+			get: Decontextify.value(def.get) || undefined,
+			set: Decontextify.value(def.set) || undefined,
+			enumerable: def.enumerable === true,
+			configurable: def.configurable === true
+		};
+	} else {
+		return {
+			value: Decontextify.value(def.value),
+			writable: def.writable === true,
+			enumerable: def.enumerable === true,
+			configurable: def.configurable === true
+		};
+	}
+};
+INSPECT_PROXY_HANDLER.defineProperty = (target, key, descriptor) => {
+	// Inspect should not set properties
+	return false;
+};
+INSPECT_PROXY_HANDLER.deleteProperty = (target, prop) => {
+	// Inspect should not set properties
+	return false;
+};
+INSPECT_PROXY_HANDLER.getPrototypeOf = (target) => {
+	try {
+		return Decontextify.value(local.Object.getPrototypeOf(target));
+	} catch (e) {
+		throw Decontextify.value(e);
+	}
+};
+INSPECT_PROXY_HANDLER.setPrototypeOf = (target) => {
+	// Inspect should not set properties
+	return false;
+};
+INSPECT_PROXY_HANDLER.has = (target, key) => {
+	try {
+		return Decontextify.value(local.Reflect.has(target, key));
+	} catch (e) {
+		throw Decontextify.value(e);
+	}
+};
+INSPECT_PROXY_HANDLER.isExtensible = target => {
+	try {
+		return Decontextify.value(local.Object.isExtensible(target));
+	} catch (e) {
+		throw Decontextify.value(e);
+	}
+};
+INSPECT_PROXY_HANDLER.ownKeys = target => {
+	try {
+		const keys = local.Reflect.ownKeys(target);
+		if (host.Array.isArray(target)) {
+			// Do this hack so that console.log(decontextify([1,2,3])) doesn't write the properties twice
+			// a la [1,2,3,'0':1,'1':2,'2':3]
+			return Decontextify.value(keys.filter(key=>typeof key!=='string' || !key.match(/^\d+$/)));
+		}
+		return Decontextify.value(local.Reflect.ownKeys(target));
+	} catch (e) {
+		throw Decontextify.value(e);
+	}
+};
+INSPECT_PROXY_HANDLER.preventExtensions = target => {
+	// Inspect should not call this
+	return false;
+};
+INSPECT_PROXY_HANDLER.enumerate = target => {
+	try {
+		return Decontextify.value(local.Reflect.enumerate(target));
+	} catch (e) {
+		throw Decontextify.value(e);
+	}
+};
 
 /**
  * Decontextify.
@@ -397,10 +521,14 @@ Decontextify.object = (object, traps, deepTraps, flags, mock) => {
 		}
 	};
 
-	const proxy = new host.Proxy(ProxyHelper.getTarget(object), host.Object.assign(base, traps, deepTraps));
-	Decontextify.proxies.set(object, proxy);
+	const resolvedTarget = ProxyHelper.getTarget(object);
+	const proxy = new host.Proxy(resolvedTarget, INSPECT_PROXY_HANDLER);
 	Decontextified.set(proxy, object);
-	return proxy;
+	// We need two proxys since nodes inspect just removes one.
+	const proxy2 = new host.Proxy(proxy, host.Object.assign(base, traps, deepTraps));
+	Decontextify.proxies.set(object, proxy2);
+	Decontextified.set(proxy2, object);
+	return proxy2;
 };
 Decontextify.value = (value, traps, deepTraps, flags, mock) => {
 	try {
@@ -791,6 +919,10 @@ Contextify.readonly = (value, mock) => {
 Contextify.protected = (value, mock) => {
 	return Contextify.value(value, null, null, {protected: true}, mock);
 };
+Contextify.connect = (outer, inner) => {
+	Decontextified.set(outer, inner);
+	Contextified.set(inner, outer);
+};
 
 const BufferMock = host.Object.create(null);
 BufferMock.allocUnsafe = function allocUnsafe(size) {
@@ -799,8 +931,19 @@ BufferMock.allocUnsafe = function allocUnsafe(size) {
 BufferMock.allocUnsafeSlow = function allocUnsafeSlow(size) {
 	return this.alloc(size);
 };
-
+const BufferOverride = host.Object.create(null);
+BufferOverride.inspect = function inspect(recurseTimes, ctx) {
+	// Mimic old behavior, could throw but didn't pass a test.
+	const max = host.INSPECT_MAX_BYTES;
+	const actualMax = Math.min(max, this.length);
+	const remaining = this.length - max;
+	let str = this.hexSlice(0, actualMax).replace(/(.{2})/g, '$1 ').trim();
+	if (remaining > 0) str += ` ... ${remaining} more byte${remaining > 1 ? 's' : ''}`;
+	return `<${this.constructor.name} ${str}>`;
+};
 const LocalBuffer = global.Buffer = Contextify.readonly(host.Buffer, BufferMock);
+Contextify.connect(host.Buffer.prototype.inspect, BufferOverride.inspect);
+
 
 const exportsMap = host.Object.create(null);
 exportsMap.Contextify = Contextify;

--- a/lib/contextify.js
+++ b/lib/contextify.js
@@ -253,7 +253,7 @@ INSPECT_PROXY_HANDLER.ownKeys = target => {
 			// a la [1,2,3,'0':1,'1':2,'2':3]
 			return Decontextify.value(keys.filter(key=>typeof key!=='string' || !key.match(/^\d+$/)));
 		}
-		return Decontextify.value(local.Reflect.ownKeys(target));
+		return Decontextify.value(keys);
 	} catch (e) {
 		throw Decontextify.value(e);
 	}

--- a/lib/main.js
+++ b/lib/main.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const vm = require('vm');
 const pa = require('path');
 const {EventEmitter} = require('events');
+const {INSPECT_MAX_BYTES} = require('buffer');
 
 const _compileToJS = function compileToJS(code, compiler, filename) {
 	if ('function' === typeof compiler) return compiler(code, filename);
@@ -211,7 +212,8 @@ class VM extends EventEmitter {
 			Set,
 			WeakSet,
 			Promise,
-			Symbol
+			Symbol,
+			INSPECT_MAX_BYTES
 		};
 
 		this._context = vm.createContext(undefined, {
@@ -368,7 +370,8 @@ class NodeVM extends EventEmitter {
 			Set,
 			WeakSet,
 			Promise,
-			Symbol
+			Symbol,
+			INSPECT_MAX_BYTES
 		};
 
 		if (this.options.nesting) {


### PR DESCRIPTION
Since node's inspect used by console.log strips one layer of proxys, wrap it in two.
The inner one uses a simple shared handler. Fixes patriksimek#241.
Also allow to connect a host object with a sandbox object. This allowes to override the Buffer.prototype.inspect method with a safer, in sandbox one, fixes patriksimek#187 for now, however we should have a look if other objects expose a custom inspect method.