### PR TITLE
Add option to disable async

### DIFF
--- a/lib/fixasync.js
+++ b/lib/fixasync.js
@@ -3,7 +3,7 @@
 // eslint-disable-next-line no-invalid-this, no-shadow
 const {GeneratorFunction, AsyncFunction, AsyncGeneratorFunction, global, Contextify, host} = this;
 // eslint-disable-next-line no-shadow
-const {Function, eval: eval_, Proxy, Promise, Object, Reflect, RegExp, VMError} = global;
+const {Function, eval: eval_, Promise, Object, Reflect, RegExp, VMError} = global;
 const {setPrototypeOf, getOwnPropertyDescriptor, defineProperty} = Object;
 const {apply: rApply, construct: rConstruct} = Reflect;
 const {test} = RegExp.prototype;
@@ -64,20 +64,30 @@ function override(obj, prop, value) {
 	defineProperty(obj, prop, desc);
 }
 
-override(Function.prototype, 'constructor', new Proxy(Function, AsyncCheckHandler));
-if (GeneratorFunction) override(GeneratorFunction.prototype, 'constructor', new Proxy(GeneratorFunction, AsyncCheckHandler));
+const proxiedFunction = new host.Proxy(Function, AsyncCheckHandler);
+override(Function.prototype, 'constructor', proxiedFunction);
+if (GeneratorFunction) {
+	Object.setPrototypeOf(GeneratorFunction, proxiedFunction);
+	override(GeneratorFunction.prototype, 'constructor', new host.Proxy(GeneratorFunction, AsyncCheckHandler));
+}
 if (AsyncFunction || AsyncGeneratorFunction) {
 	const AsyncFunctionRejectHandler = {
 		__proto__: null,
 		apply: rejectAsync,
 		construct: rejectAsync
 	};
-	if (AsyncFunction) override(AsyncFunction.prototype, 'constructor', new Proxy(AsyncFunction, AsyncFunctionRejectHandler));
-	if (AsyncGeneratorFunction) override(AsyncGeneratorFunction.prototype, 'constructor', new Proxy(AsyncGeneratorFunction, AsyncFunctionRejectHandler));
+	if (AsyncFunction) {
+		Object.setPrototypeOf(AsyncFunction, proxiedFunction);
+		override(AsyncFunction.prototype, 'constructor', new host.Proxy(AsyncFunction, AsyncFunctionRejectHandler));
+	}
+	if (AsyncGeneratorFunction) {
+		Object.setPrototypeOf(AsyncGeneratorFunction, proxiedFunction);
+		override(AsyncGeneratorFunction.prototype, 'constructor', new host.Proxy(AsyncGeneratorFunction, AsyncFunctionRejectHandler));
+	}
 }
 
 global.Function = Function.prototype.constructor;
-global.eval = new Proxy(eval_, AsyncEvalHandler);
+global.eval = new host.Proxy(eval_, AsyncEvalHandler);
 
 if (Promise) {
 	const AsyncRejectHandler = {
@@ -85,15 +95,15 @@ if (Promise) {
 		apply: rejectAsync
 	};
 
-	Promise.prototype.then = new Proxy(Promise.prototype.then, AsyncRejectHandler);
+	Promise.prototype.then = new host.Proxy(Promise.prototype.then, AsyncRejectHandler);
 	Contextify.connect(host.Promise.prototype.then, Promise.prototype.then);
 
 	if (Promise.prototype.finally) {
-		Promise.prototype.finally = new Proxy(Promise.prototype.finally, AsyncRejectHandler);
+		Promise.prototype.finally = new host.Proxy(Promise.prototype.finally, AsyncRejectHandler);
 		Contextify.connect(host.Promise.prototype.finally, Promise.prototype.finally);
 	}
 	if (Promise.prototype.catch) {
-		Promise.prototype.catch = new Proxy(Promise.prototype.catch, AsyncRejectHandler);
+		Promise.prototype.catch = new host.Proxy(Promise.prototype.catch, AsyncRejectHandler);
 		Contextify.connect(host.Promise.prototype.catch, Promise.prototype.catch);
 	}
 

--- a/lib/fixasync.js
+++ b/lib/fixasync.js
@@ -86,10 +86,15 @@ if (Promise) {
 	};
 
 	Promise.prototype.then = new Proxy(Promise.prototype.then, AsyncRejectHandler);
-	Promise.prototype.finally = new Proxy(Promise.prototype.finally, AsyncRejectHandler);
-	Promise.prototype.catch = new Proxy(Promise.prototype.catch, AsyncRejectHandler);
-
 	Contextify.connect(host.Promise.prototype.then, Promise.prototype.then);
-	Contextify.connect(host.Promise.prototype.finally, Promise.prototype.finally);
-	Contextify.connect(host.Promise.prototype.catch, Promise.prototype.catch);
+
+	if (Promise.prototype.finally) {
+		Promise.prototype.finally = new Proxy(Promise.prototype.finally, AsyncRejectHandler);
+		Contextify.connect(host.Promise.prototype.finally, Promise.prototype.finally);
+	}
+	if (Promise.prototype.catch) {
+		Promise.prototype.catch = new Proxy(Promise.prototype.catch, AsyncRejectHandler);
+		Contextify.connect(host.Promise.prototype.catch, Promise.prototype.catch);
+	}
+
 }

--- a/lib/fixasync.js
+++ b/lib/fixasync.js
@@ -1,0 +1,95 @@
+'use strict';
+
+// eslint-disable-next-line no-invalid-this, no-shadow
+const {GeneratorFunction, AsyncFunction, AsyncGeneratorFunction, global, Contextify, host} = this;
+// eslint-disable-next-line no-shadow
+const {Function, eval: eval_, Proxy, Promise, Object, Reflect, RegExp, VMError} = global;
+const {setPrototypeOf, getOwnPropertyDescriptor, defineProperty} = Object;
+const {apply: rApply, construct: rConstruct} = Reflect;
+const {test} = RegExp.prototype;
+
+function rejectAsync() {
+	throw new VMError('Async not available');
+}
+
+const testAsync = setPrototypeOf(/\basync\b/, null);
+
+function checkAsync(source) {
+	// Filter async functions, await can only be in them.
+	if (rApply(test, testAsync, [source])) {
+		throw rejectAsync();
+	}
+	return source;
+}
+
+const AsyncCheckHandler = {
+	__proto__: null,
+	apply(target, thiz, args) {
+		let i;
+		for (i=0; i<args.length; i++) {
+			// We want a exception here if args[i] is a Symbol
+			// since Function does the same thing
+			args[i] = checkAsync('' + args[i]);
+		}
+		return rApply(target, undefined, args);
+	},
+	construct(target, args, newTarget) {
+		let i;
+		for (i=0; i<args.length; i++) {
+			// We want a exception here if args[i] is a Symbol
+			// since Function does the same thing
+			args[i] = checkAsync('' + args[i]);
+		}
+		return rConstruct(target, args);
+	}
+};
+
+const AsyncEvalHandler = {
+	__proto__: null,
+	apply(target, thiz, args) {
+		if (args.length === 0) return undefined;
+		const script = args[0];
+		if (typeof script !== 'string') {
+			// Eval does the same thing
+			return script;
+		}
+		checkAsync(script);
+		return eval_(script);
+	}
+};
+
+function override(obj, prop, value) {
+	const desc = getOwnPropertyDescriptor(obj, prop);
+	desc.value = value;
+	defineProperty(obj, prop, desc);
+}
+
+override(Function.prototype, 'constructor', new Proxy(Function, AsyncCheckHandler));
+if (GeneratorFunction) override(GeneratorFunction.prototype, 'constructor', new Proxy(GeneratorFunction, AsyncCheckHandler));
+if (AsyncFunction || AsyncGeneratorFunction) {
+	const AsyncFunctionRejectHandler = {
+		__proto__: null,
+		apply: rejectAsync,
+		construct: rejectAsync
+	};
+	if (AsyncFunction) override(AsyncFunction.prototype, 'constructor', new Proxy(AsyncFunction, AsyncFunctionRejectHandler));
+	if (AsyncGeneratorFunction) override(AsyncGeneratorFunction.prototype, 'constructor', new Proxy(AsyncGeneratorFunction, AsyncFunctionRejectHandler));
+}
+
+global.Function = Function.prototype.constructor;
+global.eval = new Proxy(eval_, AsyncEvalHandler);
+
+if (Promise) {
+	const AsyncRejectHandler = {
+		__proto__: null,
+		apply: rejectAsync
+	};
+
+	Promise.prototype.then = new Proxy(Promise.prototype.then, AsyncRejectHandler);
+	Promise.prototype.finally = new Proxy(Promise.prototype.finally, AsyncRejectHandler);
+	Promise.prototype.catch = new Proxy(Promise.prototype.catch, AsyncRejectHandler);
+
+	Contextify.connect(host.Promise.prototype.then, Promise.prototype.then);
+	Contextify.connect(host.Promise.prototype.finally, Promise.prototype.finally);
+	Contextify.connect(host.Promise.prototype.catch, Promise.prototype.catch);
+}

--- a/lib/main.js
+++ b/lib/main.js
@@ -187,6 +187,11 @@ function loadScript(filename) {
 const SCRIPT_CACHE = {
 	cf: loadScript(`${__dirname}/contextify.js`).wrap('(function(require, host) { ', '\n})')._compileVM(),
 	sb: loadScript(`${__dirname}/sandbox.js`).wrap('(function (vm, host, Contextify, Decontextify, Buffer) { ', '\n})')._compileVM(),
+	fa: loadScript(`${__dirname}/fixasync.js`).wrap('(function () { ', '\n})'),
+	getGlobal: new VMScript('this'),
+	getGeneratorFunction: new VMScript('(function*(){}).constructor'),
+	getAsyncFunction: new VMScript('(async function(){}).constructor'),
+	getAsyncGeneratorFunction: new VMScript('(async function*(){}).constructor'),
 	exp: new VMScript('({exports: {}})')._compileVM(),
 	runTimeout: new VMScript('fn()', 'timeout_bridge.js')._compileVM()
 };
@@ -232,7 +237,8 @@ class VM extends EventEmitter {
 			sandbox: options.sandbox,
 			compiler: lookupCompiler(options.compiler || 'javascript'),
 			eval: options.eval === false ? false : true,
-			wasm: options.wasm === false ? false : true
+			wasm: options.wasm === false ? false : true,
+			fixAsync: options.fixAsync
 		};
 
 		const host = {
@@ -276,6 +282,30 @@ class VM extends EventEmitter {
 		Reflect.defineProperty(this, '_internal', {
 			value: SCRIPT_CACHE.cf._runInVM(this._context).call(this._context, require, host)
 		});
+
+		if (this.options.fixAsync) {
+			SCRIPT_CACHE.getGlobal._compileVM();
+			SCRIPT_CACHE.fa._compileVM();
+			const internal = {
+				__proto__: null,
+				global: SCRIPT_CACHE.getGlobal._runInVM(this._context),
+				Contextify: this._internal.Contextify,
+				host: host
+			};
+			try {
+				SCRIPT_CACHE.getGeneratorFunction._compileVM();
+				internal.GeneratorFunction = SCRIPT_CACHE.getGeneratorFunction._runInVM(this._context);
+			} catch (ex) {}
+			try {
+				SCRIPT_CACHE.getAsyncFunction._compileVM();
+				internal.AsyncFunction = SCRIPT_CACHE.getAsyncFunction._runInVM(this._context);
+			} catch (ex) {}
+			try {
+				SCRIPT_CACHE.getAsyncGeneratorFunction._compileVM();
+				internal.AsyncGeneratorFunction = SCRIPT_CACHE.getAsyncGeneratorFunction._runInVM(this._context);
+			} catch (ex) {}
+			SCRIPT_CACHE.fa._runInVM(this._context).call(internal);
+		}
 
 		// prepare global sandbox
 		if (this.options.sandbox) {
@@ -331,6 +361,11 @@ class VM extends EventEmitter {
 
 	run(code, filename) {
 		const script = code instanceof VMScript ? code : new VMScript(code, filename, {compiler: this.options.compiler});
+
+		if (this.options.fixAsync && /\basync\b/.test(script.code)) {
+			throw new VMError('Async not available');
+		}
+
 		script._compileVM();
 
 		if (!this.options.timeout) {

--- a/test/vm.js
+++ b/test/vm.js
@@ -350,8 +350,8 @@ describe('VM', () => {
 		assert.throws(() => vm2.run('new Function("as"+"ync function(){}")'), /Async not available/, '#2');
 		assert.throws(() => vm2.run('new (function*(){}).constructor("as"+"ync function(){}")'), /Async not available/, '#3');
 		assert.throws(() => vm2.run('Promise.resolve().then(function(){})'), /Async not available/, '#4');
-		assert.throws(() => vm2.run('Promise.resolve().finally(function(){})'), /Async not available/, '#5');
-		assert.throws(() => vm2.run('Promise.resolve().catch(function(){})'), /Async not available/, '#6');
+		if (Promise.prototype.finally) assert.throws(() => vm2.run('Promise.resolve().finally(function(){})'), /Async not available/, '#5');
+		if (Promise.prototype.catch) assert.throws(() => vm2.run('Promise.resolve().catch(function(){})'), /Async not available/, '#6');
 		assert.throws(() => vm2.run('eval("as"+"ync function(){}")'), /Async not available/, '#7');
 	});
 

--- a/test/vm.js
+++ b/test/vm.js
@@ -353,6 +353,8 @@ describe('VM', () => {
 		if (Promise.prototype.finally) assert.throws(() => vm2.run('Promise.resolve().finally(function(){})'), /Async not available/, '#5');
 		if (Promise.prototype.catch) assert.throws(() => vm2.run('Promise.resolve().catch(function(){})'), /Async not available/, '#6');
 		assert.throws(() => vm2.run('eval("as"+"ync function(){}")'), /Async not available/, '#7');
+		assert.strictEqual(vm2.run('Object.getPrototypeOf((function*(){}).constructor)'), vm2.run('Function'), '#8');
+		assert.throws(() => vm2.run('Function')('async function(){}'), /Async not available/, '#9');
 	});
 
 	it('various attacks #1', () => {

--- a/test/vm.js
+++ b/test/vm.js
@@ -344,6 +344,17 @@ describe('VM', () => {
 		});
 	}
 
+	it('async', () => {
+		const vm2 = new VM({fixAsync: true});
+		assert.throws(() => vm2.run('(async function(){})'), /Async not available/, '#1');
+		assert.throws(() => vm2.run('new Function("as"+"ync function(){}")'), /Async not available/, '#2');
+		assert.throws(() => vm2.run('new (function*(){}).constructor("as"+"ync function(){}")'), /Async not available/, '#3');
+		assert.throws(() => vm2.run('Promise.resolve().then(function(){})'), /Async not available/, '#4');
+		assert.throws(() => vm2.run('Promise.resolve().finally(function(){})'), /Async not available/, '#5');
+		assert.throws(() => vm2.run('Promise.resolve().catch(function(){})'), /Async not available/, '#6');
+		assert.throws(() => vm2.run('eval("as"+"ync function(){}")'), /Async not available/, '#7');
+	});
+
 	it('various attacks #1', () => {
 		const vm2 = new VM({sandbox: {log: console.log, boom: () => {
 			throw new Error();


### PR DESCRIPTION
This is done by checking if the source contains the word 'async'.
This catches await, since it can only be used in async functions.
It wraps eval and function ctors and injects the async check there too.
This has some side effects like no direct eval support.
The option is currently opt in.
This should fix https://github.com/patriksimek/vm2/issues/180.