### PR TITLE
Fix for non-configurable property access

### DIFF
--- a/lib/contextify.js
+++ b/lib/contextify.js
@@ -18,6 +18,11 @@ local.Reflect.apply = Reflect.apply;
 local.Reflect.set = Reflect.set;
 local.Reflect.deleteProperty = Reflect.deleteProperty;
 local.Reflect.has = Reflect.has;
+local.Reflect.defineProperty = Reflect.defineProperty;
+local.Reflect.setPrototypeOf = Reflect.setPrototypeOf;
+local.Reflect.isExtensible = Reflect.isExtensible;
+local.Reflect.preventExtensions = Reflect.preventExtensions;
+local.Reflect.getOwnPropertyDescriptor = Reflect.getOwnPropertyDescriptor;
 
 // global is originally prototype of host.Object so it can be used to climb up from the sandbox.
 Object.setPrototypeOf(global, Object.prototype);
@@ -51,18 +56,16 @@ function instanceOf(value, construct) {
 	try {
 		return host.Reflect.apply(hasInstance, construct, [value]);
 	} catch (ex) {
-		// Never pass the handled expcetion through!
+		// Never pass the handled exception through!
 		throw new VMError('Unable to perform instanceOf check.');
 		// This exception actually never get to the user. It only instructs the caller to return null because we wasn't able to perform instanceOf check.
 	}
 }
 
-const SHARED_ARROW = ()=>{};
-function SHARED_FUNC() {}
-const SHARED_ARRAY = [];
 const SHARED_OBJECT = {__proto__: null};
 
-function getBaseObject(obj) {
+function createBaseObject(obj) {
+	let base;
 	if (typeof obj === 'function') {
 		try {
 			// eslint-disable-next-line no-new
@@ -72,14 +75,22 @@ function getBaseObject(obj) {
 					return this;
 				}
 			})();
+			// eslint-disable-next-line func-names
+			base = function() {};
+			base.prototype = null;
 		} catch (e) {
-			return SHARED_ARROW;
+			base = () => {};
 		}
-		return SHARED_FUNC;
 	} else if (host.Array.isArray(obj)) {
-		return SHARED_ARRAY;
+		base = [];
+	} else {
+		return {__proto__: null};
 	}
-	return SHARED_OBJECT;
+	if (!local.Reflect.setPrototypeOf(base, null)) {
+		// Should not happen
+		return null;
+	}
+	return base;
 }
 
 /**
@@ -107,6 +118,44 @@ function throwCallerCalleeArgumentsAccess(key) {
 	'use strict';
 	throwCallerCalleeArgumentsAccess[key];
 	return new VMError('Unreachable');
+}
+
+function unexpected() {
+	throw new VMError('Should not happen');
+}
+
+function doPreventExtensions(target, object, doProxy) {
+	const keys = local.Reflect.ownKeys(object);
+	for (let i = 0; i < keys.length; i++) {
+		const key = keys[i];
+		let desc = local.Reflect.getOwnPropertyDescriptor(object, key);
+		if (!desc) continue;
+		if (!local.Reflect.setPrototypeOf(desc, null)) unexpected();
+		if (!desc.configurable) {
+			const current = local.Reflect.getOwnPropertyDescriptor(target, key);
+			if (current && !current.configurable) continue;
+			if (desc.get || desc.set) {
+				desc.get = doProxy(desc.get);
+				desc.set = doProxy(desc.set);
+			} else {
+				desc.value = doProxy(desc.value);
+			}
+		} else {
+			if (desc.get || desc.set) {
+				desc = {
+					__proto__: null,
+					configurable: true,
+					enumberable: desc.enumberable,
+					writeable: true,
+					value: null
+				};
+			} else {
+				desc.value = null;
+			}
+		}
+		if (!local.Reflect.defineProperty(target, key, desc)) unexpected();
+	}
+	if (!local.Reflect.preventExtensions(target)) unexpected();
 }
 
 /**
@@ -269,25 +318,46 @@ Decontextify.object = (object, traps, deepTraps, flags, mock) => {
 		// TypeError: 'getOwnPropertyDescriptor' on proxy: trap reported non-configurability for property '<prop>'
 		// which is either non-existant or configurable in the proxy target
 
+		let desc;
 		if (!def) {
 			return undefined;
 		} else if (def.get || def.set) {
-			return {
+			desc = {
+				__proto__: null,
 				get: Decontextify.value(def.get) || undefined,
 				set: Decontextify.value(def.set) || undefined,
 				enumerable: def.enumerable === true,
 				configurable: def.configurable === true
 			};
 		} else {
-			return {
+			desc = {
+				__proto__: null,
 				value: Decontextify.value(def.value),
 				writable: def.writable === true,
 				enumerable: def.enumerable === true,
 				configurable: def.configurable === true
 			};
 		}
+		if (!desc.configurable) {
+			try {
+				def = host.Object.getOwnPropertyDescriptor(target, prop);
+				if (!def || def.configurable) {
+					local.Reflect.defineProperty(target, prop, desc);
+				}
+			} catch (e) {
+				// Should not happen.
+			}
+		}
+		return desc;
 	};
 	base.defineProperty = (target, key, descriptor) => {
+		let success = false;
+		try {
+			success = local.Reflect.setPrototypeOf(descriptor, null);
+		} catch (e) {
+			// Should not happen
+		}
+		if (!success) return false;
 		// There's a chance accessing a property throws an error so we must not access them
 		// in try catch to prevent contextyfing local objects.
 
@@ -305,10 +375,19 @@ Decontextify.object = (object, traps, deepTraps, flags, mock) => {
 		}
 
 		try {
-			return host.Object.defineProperty(target, key, propertyDescriptor);
+			success = local.Reflect.defineProperty(object, key, propertyDescriptor);
 		} catch (e) {
 			throw Decontextify.value(e);
 		}
+		if (success && descriptor.configurable) {
+			try {
+				local.Reflect.defineProperty(target, key, descriptor);
+			} catch (e) {
+				// This should not happen.
+				return false;
+			}
+		}
+		return success;
 	};
 	base.deleteProperty = (target, prop) => {
 		try {
@@ -331,11 +410,22 @@ Decontextify.object = (object, traps, deepTraps, flags, mock) => {
 		}
 	};
 	base.isExtensible = target => {
+		let result;
 		try {
-			return Decontextify.value(local.Object.isExtensible(object));
+			result = local.Reflect.isExtensible(object);
 		} catch (e) {
 			throw Decontextify.value(e);
 		}
+		if (!result) {
+			try {
+				if (local.Reflect.isExtensible(target)) {
+					doPreventExtensions(target, object, obj => Contextify.value(obj, null, deepTraps, flags));
+				}
+			} catch (e) {
+				// Should not happen
+			}
+		}
+		return result;
 	};
 	base.ownKeys = target => {
 		try {
@@ -345,12 +435,22 @@ Decontextify.object = (object, traps, deepTraps, flags, mock) => {
 		}
 	};
 	base.preventExtensions = target => {
+		let success;
 		try {
-			local.Object.preventExtensions(object);
-			return true;
+			success = local.Reflect.preventExtensions(object);
 		} catch (e) {
-			throw Decontextify.value(e);
+			throw Contextify.value(e);
 		}
+		if (success) {
+			try {
+				if (local.Reflect.isExtensible(target)) {
+					doPreventExtensions(target, object, obj => Contextify.value(obj, null, deepTraps, flags));
+				}
+			} catch (e) {
+				// Should not happen
+			}
+		}
+		return success;
 	};
 	base.enumerate = target => {
 		try {
@@ -368,6 +468,7 @@ Decontextify.object = (object, traps, deepTraps, flags, mock) => {
 		shallow = {
 			__proto__: null,
 			ownKeys: base.ownKeys,
+			// TODO this get will call getOwnPropertyDescriptor of target all the time.
 			get: origGet
 		};
 		base.ownKeys = target => {
@@ -388,9 +489,9 @@ Decontextify.object = (object, traps, deepTraps, flags, mock) => {
 		shallow = SHARED_OBJECT;
 	}
 
-	const proxy = new host.Proxy(getBaseObject(object), base);
+	const proxy = new host.Proxy(createBaseObject(object), base);
 	Decontextified.set(proxy, object);
-	// We need two proxys since nodes inspect just removes one.
+	// We need two proxies since nodes inspect just removes one.
 	const proxy2 = new host.Proxy(proxy, shallow);
 	Decontextify.proxies.set(object, proxy2);
 	Decontextified.set(proxy2, object);
@@ -619,25 +720,46 @@ Contextify.object = (object, traps, deepTraps, flags, mock) => {
 		// TypeError: 'getOwnPropertyDescriptor' on proxy: trap reported non-configurability for property '<prop>'
 		// which is either non-existant or configurable in the proxy target
 
+		let desc;
 		if (!def) {
 			return undefined;
 		} else if (def.get || def.set) {
-			return {
+			desc = {
+				__proto__: null,
 				get: Contextify.value(def.get, null, deepTraps, flags) || undefined,
 				set: Contextify.value(def.set, null, deepTraps, flags) || undefined,
 				enumerable: def.enumerable === true,
 				configurable: def.configurable === true
 			};
 		} else {
-			return {
+			desc = {
+				__proto__: null,
 				value: Contextify.value(def.value, null, deepTraps, flags),
 				writable: def.writable === true,
 				enumerable: def.enumerable === true,
 				configurable: def.configurable === true
 			};
 		}
+		if (!desc.configurable) {
+			try {
+				def = host.Object.getOwnPropertyDescriptor(target, prop);
+				if (!def || def.configurable) {
+					local.Reflect.defineProperty(target, prop, desc);
+				}
+			} catch (e) {
+				// Should not happen.
+			}
+		}
+		return desc;
 	};
 	base.defineProperty = (target, key, descriptor) => {
+		let success = false;
+		try {
+			success = local.Reflect.setPrototypeOf(descriptor, null);
+		} catch (e) {
+			// Should not happen
+		}
+		if (!success) return false;
 		// There's a chance accessing a property throws an error so we must not access them
 		// in try catch to prevent contextyfing local objects.
 
@@ -663,10 +785,19 @@ Contextify.object = (object, traps, deepTraps, flags, mock) => {
 		}
 
 		try {
-			return host.Object.defineProperty(object, key, propertyDescriptor);
+			success = host.Reflect.defineProperty(object, key, propertyDescriptor);
 		} catch (e) {
 			throw Contextify.value(e);
 		}
+		if (success && descriptor.configurable) {
+			try {
+				local.Reflect.defineProperty(target, key, descriptor);
+			} catch (e) {
+				// This should not happen.
+				return false;
+			}
+		}
+		return success;
 	};
 	base.deleteProperty = (target, prop) => {
 		try {
@@ -689,11 +820,22 @@ Contextify.object = (object, traps, deepTraps, flags, mock) => {
 		}
 	};
 	base.isExtensible = target => {
+		let result;
 		try {
-			return Contextify.value(host.Object.isExtensible(object));
+			result = host.Reflect.isExtensible(object);
 		} catch (e) {
 			throw Contextify.value(e);
 		}
+		if (!result) {
+			try {
+				if (local.Reflect.isExtensible(target)) {
+					doPreventExtensions(target, object, obj => Decontextify.value(obj, null, deepTraps, flags));
+				}
+			} catch (e) {
+				// Should not happen
+			}
+		}
+		return result;
 	};
 	base.ownKeys = target => {
 		try {
@@ -703,12 +845,22 @@ Contextify.object = (object, traps, deepTraps, flags, mock) => {
 		}
 	};
 	base.preventExtensions = target => {
+		let success;
 		try {
-			host.Object.preventExtensions(object);
-			return true;
+			success = local.Reflect.preventExtensions(object);
 		} catch (e) {
 			throw Contextify.value(e);
 		}
+		if (success) {
+			try {
+				if (local.Reflect.isExtensible(target)) {
+					doPreventExtensions(target, object, obj => Decontextify.value(obj, null, deepTraps, flags));
+				}
+			} catch (e) {
+				// Should not happen
+			}
+		}
+		return success;
 	};
 	base.enumerate = target => {
 		try {
@@ -718,7 +870,7 @@ Contextify.object = (object, traps, deepTraps, flags, mock) => {
 		}
 	};
 
-	const proxy = new host.Proxy(getBaseObject(object), host.Object.assign(base, traps, deepTraps));
+	const proxy = new host.Proxy(createBaseObject(object), host.Object.assign(base, traps, deepTraps));
 	Contextify.proxies.set(object, proxy);
 	Contextified.set(proxy, object);
 	return proxy;

--- a/lib/contextify.js
+++ b/lib/contextify.js
@@ -439,7 +439,7 @@ Decontextify.object = (object, traps, deepTraps, flags, mock) => {
 		try {
 			success = local.Reflect.preventExtensions(object);
 		} catch (e) {
-			throw Contextify.value(e);
+			throw Decontextify.value(e);
 		}
 		if (success) {
 			try {

--- a/test/vm.js
+++ b/test/vm.js
@@ -378,14 +378,30 @@ describe('VM', () => {
 
 	it('frozen unconfigurable access', () => {
 		const vm2 = new VM();
+		const obj = {};
 
 		assert.doesNotThrow(()=>{
-			vm2.run('x => x.prop')(Object.freeze({prop: 'good'}));
+			vm2.run('x => x.prop')(Object.freeze({prop: {}}));
 		});
 
 		assert.doesNotThrow(()=>{
-			vm2.run('x => x.prop')(Object.defineProperty({}, 'prop', {value: 'good'}));
+			vm2.run('x => Object.getOwnPropertyDescriptor(x, "prop")')(Object.freeze({prop: {}}));
 		});
+
+		assert.doesNotThrow(()=>{
+			vm2.run('x => x.prop')(Object.defineProperty({}, 'prop', {value: {}}));
+		});
+
+		assert.doesNotThrow(()=>{
+			vm2.run('x => Object.isExtensible(x)')(Object.freeze({prop: {}}));
+		});
+
+		assert.doesNotThrow(()=>{
+			vm2.run('x => {Object.preventExtensions(x); Object.getOwnPropertyDescriptor(x, "prop")}')({prop: {}});
+		});
+
+		assert.strictEqual(vm2.run('x => {Object.preventExtensions(x); return Object.getOwnPropertyDescriptor(x, "prop").value}')({prop: obj}), obj);
+
 	});
 
 	it('various attacks #1', () => {
@@ -603,22 +619,18 @@ describe('VM', () => {
 		let vm2 = new VM();
 
 		// The Buffer.from("") is only used to get instance of object contextified from the host
-		assert.throws(() => vm2.run(`
-			try {
-				Object.defineProperty(Buffer.from(""), "x", {
-					get set() {
-						Object.defineProperty(Object.prototype, "get", {
-							get() {
-								throw x=>x.constructor.constructor("return process")();
-							}
-						});
-						return ()=>{};
-					}
-				});
-			} catch(e) {
-				e({});
-			}
-		`), /process is not defined/, '#1');
+		assert.doesNotThrow(() => vm2.run(`
+			Object.defineProperty(Buffer.from(""), "x", {
+				get set() {
+					Object.defineProperty(Object.prototype, "get", {
+						get() {
+							throw new Error();
+						}
+					});
+					return ()=>{};
+				}
+			});
+		`), '#1');
 
 		vm2 = new VM({
 			sandbox: {

--- a/test/vm.js
+++ b/test/vm.js
@@ -823,7 +823,7 @@ describe('VM', () => {
 
 		const vm2 = new VM();
 
-		assert.strictEqual(vm2.run(`
+		assert.strictEqual(vm2.run(`(function(){
 			var process;
 			Object.defineProperty(Object.prototype, "set", {get(){
 				delete Object.prototype.set;
@@ -843,7 +843,7 @@ describe('VM', () => {
 			}catch(e){
 				e.x = Buffer.from;
 			}
-			process
+			return process;})()
 		`), undefined, '#1');
 	});
 


### PR DESCRIPTION
This should fix https://github.com/patriksimek/vm2/issues/272.
When a non-configurable property is requested, it is now copied into the proxy target and therfore shouldn't violate the proxy target handler rules any more.