### PR TITLE
Require helpers statically in main.

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,12 @@
+// source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
+function escapeRegExp(string) {
+	return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}
+
+function match(wildcard, s) {
+	const regexString = escapeRegExp(wildcard).replace(/\\\*/g, '\\S*').replace(/\\\?/g, '.');
+	const regex = new RegExp(regexString);
+	return regex.test(s);
+}
+
+module.exports = {match};

--- a/lib/main.js
+++ b/lib/main.js
@@ -25,6 +25,7 @@ const vm = require('vm');
 const pa = require('path');
 const {EventEmitter} = require('events');
 const {INSPECT_MAX_BYTES} = require('buffer');
+const helpers = require('./helpers.js');
 
 /**
  * Load a script from a file and compile it.
@@ -1181,7 +1182,8 @@ const HOST = {
 	Symbol,
 	INSPECT_MAX_BYTES,
 	VM,
-	NodeVM
+	NodeVM,
+	helpers
 };
 
 exports.VMError = VMError;

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -6,7 +6,6 @@
 const {Script} = host.require('vm');
 const fs = host.require('fs');
 const pa = host.require('path');
-const {match} = host.require('../lib/wildcard');
 
 const BUILTIN_MODULES = host.process.binding('natives');
 const parseJSON = JSON.parse;
@@ -265,7 +264,7 @@ return ((vm, host) => {
 				if (typeof vm.options.require.external === 'object') {
 					const { external, transitive } = _parseExternalOptions(vm.options.require.external);
 
-					const isWhitelisted = external.some(ext => match(ext, moduleName)) || (transitive && parentAllowsTransitive);
+					const isWhitelisted = external.some(ext => host.helpers.match(ext, moduleName)) || (transitive && parentAllowsTransitive);
 					if (!isWhitelisted) {
 						throw new VMError(`The module '${moduleName}' is not whitelisted in VM.`, 'EDENIED');
 					}

--- a/lib/wildcard.js
+++ b/lib/wildcard.js
@@ -1,7 +1,0 @@
-const match = (wildcard, s) => {
-	const regexString = wildcard.replace(/\*/g, '\\S*').replace(/\?/g, '.');
-	const regex = new RegExp(regexString);
-	return regex.test(s);
-};
-
-module.exports = {match};

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-const {match} = require('../lib/wildcard');
+const {match} = require('../lib/helpers');
 const assert = require('assert');
 
 describe('wildcard matching', () => {


### PR DESCRIPTION
This should fix packing programs not including the helpers.js.
Also escape the regex better.