### PR TITLE
Add internal to support trusted libs without contextify for class ext…

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-const {Script} = host.require('vm');
+const { Script } = host.require('vm');
 const fs = host.require('fs');
 const pa = host.require('path');
 
@@ -20,8 +20,8 @@ return ((vm, host) => {
 	const global = this;
 
 	const TIMERS = new host.WeakMap(); // Contains map of timers created inside sandbox
-	const BUILTINS = {__proto__: null};
-	const CACHE = {__proto__: null};
+	const BUILTINS = { __proto__: null };
+	const CACHE = { __proto__: null };
 	const EXTENSIONS = {
 		__proto__: null,
 		['.json'](module, filename) {
@@ -180,7 +180,7 @@ return ((vm, host) => {
 	 */
 
 	const _requireBuiltin = (moduleName) => {
-		if (moduleName === 'buffer') return ({Buffer});
+		if (moduleName === 'buffer') return ({ Buffer });
 		if (BUILTINS[moduleName]) return BUILTINS[moduleName].exports; // Only compiled builtins are stored here
 
 		if (moduleName === 'util') {
@@ -239,7 +239,7 @@ return ((vm, host) => {
 			let requireObj;
 			try {
 				const optionsObj = vm.options;
-				if (optionsObj.nesting && moduleName === 'vm2') return {VM: Contextify.readonly(host.VM), NodeVM: Contextify.readonly(host.NodeVM)};
+				if (optionsObj.nesting && moduleName === 'vm2') return { VM: Contextify.readonly(host.VM), NodeVM: Contextify.readonly(host.NodeVM) };
 				requireObj = optionsObj.require;
 			} catch (e) {
 				throw Contextify.value(e);
@@ -252,10 +252,26 @@ return ((vm, host) => {
 			let filename;
 			let allowRequireTransitive = false;
 
+			// internal?
+			// consider you have trusted libraries and want to import them without contextify
+			// this lets us to extend classes from trusted classes
+			try {
+				const { internal } = requireObj;
+				if (internal) {
+					const mockModule = internal[moduleName];
+					if (mockModule) {
+						// do not contextify
+						return mockModule;
+					}
+				}
+			} catch (e) {
+				throw Contextify.value(e);
+			}
+
 			// Mock?
 
 			try {
-				const {mock} = requireObj;
+				const { mock } = requireObj;
 				if (mock) {
 					const mockModule = mock[moduleName];
 					if (mockModule) {
@@ -502,7 +518,7 @@ return ((vm, host) => {
 		return this;
 	}
 
-	const {argv: optionArgv, env: optionsEnv} = options;
+	const { argv: optionArgv, env: optionsEnv } = options;
 
 	// FIXME wrong class structure
 	global.process = {
@@ -652,8 +668,8 @@ return ((vm, host) => {
 					throw Contextify.value(e);
 				}
 			},
-			time() {},
-			timeEnd() {},
+			time() { },
+			timeEnd() { },
 			trace(...args) {
 				try {
 					// FIXME ...args has side effects


### PR DESCRIPTION
I like to extend classes from some trusted base classes
thats not possible right now but if you let us import some trusted libraries without contextify
thats going to be amazing