### PR TITLE
Fix uninitialized buffer allocation

### DIFF
--- a/lib/contextify.js
+++ b/lib/contextify.js
@@ -612,6 +612,11 @@ Contextify.function = (fnc, traps, deepTraps, flags, mock) => {
 	let proxy;
 
 	base.apply = (target, context, args) => {
+		// Fixes buffer unsafe allocation for node v6/7
+		if (host.version < 8 && fnc === host.Buffer && 'number' === typeof args[0]) {
+			args[0] = new local.Array(args[0]).fill(0);
+		}
+
 		context = Decontextify.value(context);
 
 		// Set context of all arguments to host's context.
@@ -626,7 +631,7 @@ Contextify.function = (fnc, traps, deepTraps, flags, mock) => {
 	base.construct = (target, args, newTarget) => {
 		// Fixes buffer unsafe allocation for node v6/7
 		if (host.version < 8 && fnc === host.Buffer && 'number' === typeof args[0]) {
-			args[0] = new Array(args[0]).fill(0);
+			args[0] = new local.Array(args[0]).fill(0);
 		}
 
 		args = Decontextify.arguments(args);

--- a/test/vm.js
+++ b/test/vm.js
@@ -553,6 +553,21 @@ describe('VM', () => {
 		assert.strictEqual(vm2.run(`
 			class MyBuffer extends Buffer {}; MyBuffer.alloc(100).toString('hex');
 		`), '00'.repeat(100), '#4');
+
+		assert.strictEqual(vm2.run(`
+			new Buffer(100).toString('hex');
+		`), '00'.repeat(100), '#5');
+
+		if (NODE_VERSION < 8) {
+			assert.strictEqual(vm2.run(`
+				Buffer(100).toString('hex');
+			`), '00'.repeat(100), '#6');
+		}
+
+		assert.strictEqual(vm2.run(`
+			class MyBuffer2 extends Buffer {}; new MyBuffer2(100).toString('hex');
+		`), '00'.repeat(100), '#7');
+
 	});
 
 	it('instanceof attack', () => {


### PR DESCRIPTION
Duplicating the logic from the construct proxy handler to the apply proxy handler. Should fix https://github.com/patriksimek/vm2/issues/318.