### PR TITLE
feat: add microtaskMode support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,6 +58,11 @@ export interface VMOptions {
    * If set to `true` any attempt to run code using async will throw a `VMError` (default: `false`).
    */
   fixAsync?: boolean;
+  /**
+   * If set to afterEvaluate, microtasks (tasks scheduled through Promises and async functions) will be run immediately after the script has run. They are included in the timeout and breakOnSigint scopes in that case.
+   */
+  microtaskMode?: "afterEvaluate";
+
 }
 
 /**
@@ -74,13 +79,13 @@ export interface NodeVMOptions extends VMOptions {
   wrapper?: "commonjs" | "none";
   /** File extensions that the internal module resolver should accept. */
   sourceExtensions?: string[];
-  /** 
-   * Array of arguments passed to `process.argv`. 
-	 * This object will not be copied and the script can change this object. 
+  /**
+   * Array of arguments passed to `process.argv`.
+	 * This object will not be copied and the script can change this object.
    */
   argv?: string[];
-  /** 
-   * Environment map passed to `process.env`. 
+  /**
+   * Environment map passed to `process.env`.
 	 * This object will not be copied and the script can change this object.
    */
   env?: any;
@@ -185,8 +190,8 @@ export class VMScript {
   readonly lineOffset: number;
   readonly columnOffset: number;
   readonly compiler: "javascript" | "coffeescript" | CompilerFunction;
-  /** 
-   * Wraps the code 
+  /**
+   * Wraps the code
    * @deprecated
    */
   wrap(prefix: string, postfix: string): this;

--- a/lib/main.js
+++ b/lib/main.js
@@ -29,7 +29,7 @@ const helpers = require('./helpers.js');
 
 /**
  * Load a script from a file and compile it.
- * 
+ *
  * @private
  * @param {string} filename - File to load and compile to a script.
  * @param {string} prefix - Prefix for the script.
@@ -46,7 +46,7 @@ function loadAndCompileScript(filename, prefix, suffix) {
 
 /**
  * Cache where we can cache some things
- * 
+ *
  * @private
  * @property {?compileCallback} coffeeScriptCompiler - The coffee script compiler or null if not yet used.
  * @property {?Object} timeoutContext - The context used for the timeout functionality of null if not yet used.
@@ -74,7 +74,7 @@ const CACHE = {
 
 /**
  * Default run options for vm.Script.runInContext
- * 
+ *
  * @private
  */
 const DEFAULT_RUN_OPTIONS = {displayErrors: false};
@@ -82,7 +82,7 @@ const DEFAULT_RUN_OPTIONS = {displayErrors: false};
 /**
  * Returns the cached coffee script compiler or loads it
  * if it is not found in the cache.
- * 
+ *
  * @private
  * @return {compileCallback} The coffee script compiler.
  * @throws {VMError} If the coffee-script module can't be found.
@@ -103,7 +103,7 @@ function getCoffeeScriptCompiler() {
 
 /**
  * The JavaScript compiler, just a identity function.
- * 
+ *
  * @private
  * @type {compileCallback}
  * @param {string} code - The JavaScript code.
@@ -116,7 +116,7 @@ function jsCompiler(code, filename) {
 
 /**
  * Look up the compiler for a specific name.
- * 
+ *
  * @private
  * @param {(string|compileCallback)} compiler - A compile callback or the name of the compiler.
  * @return {compileCallback} The resolved compiler.
@@ -142,7 +142,7 @@ function lookupCompiler(compiler) {
 
 /**
  * Remove the shebang from source code.
- * 
+ *
  * @private
  * @param {string} code - Code from which to remove the shebang.
  * @return {string} code without the shebang.
@@ -162,7 +162,7 @@ class VMScript {
 	/**
 	 * The script code with wrapping. If set will invalidate the cache.<br>
 	 * Writable only for backwards compatibility.
-	 * 
+	 *
 	 * @public
 	 * @readonly
 	 * @member {string} code
@@ -171,7 +171,7 @@ class VMScript {
 
 	/**
 	 * The filename used for this script.
-	 * 
+	 *
 	 * @public
 	 * @readonly
 	 * @since v3.9.0
@@ -181,7 +181,7 @@ class VMScript {
 
 	/**
 	 * The line offset use for stack traces.
-	 * 
+	 *
 	 * @public
 	 * @readonly
 	 * @since v3.9.0
@@ -191,7 +191,7 @@ class VMScript {
 
 	/**
 	 * The column offset use for stack traces.
-	 * 
+	 *
 	 * @public
 	 * @readonly
 	 * @since v3.9.0
@@ -201,7 +201,7 @@ class VMScript {
 
 	/**
 	 * The compiler to use to get the JavaScript code.
-	 * 
+	 *
 	 * @public
 	 * @readonly
 	 * @since v3.9.0
@@ -211,7 +211,7 @@ class VMScript {
 
 	/**
 	 * The prefix for the script.
-	 * 
+	 *
 	 * @private
 	 * @member {string} _prefix
 	 * @memberOf VMScript#
@@ -219,7 +219,7 @@ class VMScript {
 
 	/**
 	 * The suffix for the script.
-	 * 
+	 *
 	 * @private
 	 * @member {string} _suffix
 	 * @memberOf VMScript#
@@ -227,7 +227,7 @@ class VMScript {
 
 	/**
 	 * The compiled vm.Script for the VM or if not compiled <code>null</code>.
-	 * 
+	 *
 	 * @private
 	 * @member {?vm.Script} _compiledVM
 	 * @memberOf VMScript#
@@ -235,7 +235,7 @@ class VMScript {
 
 	/**
 	 * The compiled vm.Script for the NodeVM or if not compiled <code>null</code>.
-	 * 
+	 *
 	 * @private
 	 * @member {?vm.Script} _compiledNodeVM
 	 * @memberOf VMScript#
@@ -243,7 +243,7 @@ class VMScript {
 
 	/**
 	 * The resolved compiler to use to get the JavaScript code.
-	 * 
+	 *
 	 * @private
 	 * @readonly
 	 * @member {compileCallback} _compiler
@@ -252,7 +252,7 @@ class VMScript {
 
 	/**
 	 * The script to run without wrapping.
-	 * 
+	 *
 	 * @private
 	 * @member {string} _code
 	 * @memberOf VMScript#
@@ -400,7 +400,7 @@ class VMScript {
 
 	/**
 	 * Get the compiled code.
-	 * 
+	 *
 	 * @private
 	 * @return {string} The code.
 	 */
@@ -413,7 +413,7 @@ class VMScript {
 
 	/**
 	 * Compiles this script to a vm.Script.
-	 * 
+	 *
 	 * @private
 	 * @param {string} prefix - JavaScript code that will be used as prefix.
 	 * @param {string} suffix - JavaScript code that will be used as suffix.
@@ -431,7 +431,7 @@ class VMScript {
 
 	/**
 	 * Will return the cached version of the script intended for VM or compile it.
-	 * 
+	 *
 	 * @private
 	 * @return {vm.Script} The compiled script
 	 * @throws {SyntaxError} If there is a syntax error in the script.
@@ -446,7 +446,7 @@ class VMScript {
 
 	/**
 	 * Will return the cached version of the script intended for NodeVM or compile it.
-	 * 
+	 *
 	 * @private
 	 * @return {vm.Script} The compiled script
 	 * @throws {SyntaxError} If there is a syntax error in the script.
@@ -462,20 +462,20 @@ class VMScript {
 }
 
 /**
- * 
+ *
  * This callback will be called and has a specific time to finish.<br>
  * No parameters will be supplied.<br>
  * If parameters are required, use a closure.
- * 
+ *
  * @private
  * @callback runWithTimeout
- * @return {*} 
- * 
+ * @return {*}
+ *
  */
 
 /**
  * Run a function with a specific timeout.
- * 
+ *
  * @private
  * @param {runWithTimeout} fn - Function to run with the specific timeout.
  * @param {number} timeout - The amount of time to give the function to finish.
@@ -505,7 +505,7 @@ function doWithTimeout(fn, timeout) {
 
 /**
  * Creates the hook to check for the use of async.
- * 
+ *
  * @private
  * @param {*} internal - The internal vm object.
  * @return {*} The hook function
@@ -575,7 +575,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * The compiler to use to get the JavaScript code.
-	 * 
+	 *
 	 * @public
 	 * @readonly
 	 * @since v3.9.0
@@ -585,7 +585,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * The context for this sandbox.
-	 * 
+	 *
 	 * @private
 	 * @readonly
 	 * @member {Object} _context
@@ -594,7 +594,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * The internal methods for this sandbox.
-	 * 
+	 *
 	 * @private
 	 * @readonly
 	 * @member {{Contextify: Object, Decontextify: Object, Buffer: Object, sandbox:Object}} _internal
@@ -603,7 +603,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * The resolved compiler to use to get the JavaScript code.
-	 * 
+	 *
 	 * @private
 	 * @readonly
 	 * @member {compileCallback} _compiler
@@ -612,7 +612,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * The hook called when some events occurs.
-	 * 
+	 *
 	 * @private
 	 * @readonly
 	 * @since v3.9.2
@@ -633,6 +633,11 @@ class VM extends EventEmitter {
 	 * @param {boolean} [options.wasm=true] - Allow to run wasm code.<br>
 	 * Only available for node v10+.
 	 * @param {boolean} [options.fixAsync=false] - Filters for async functions.
+	 * Only available for node v14.6+.
+	 * @param {string} [options.microtaskMode= undefined] - If set to `afterEvaluate`,
+	 * microtasks (tasks scheduled through `Promise`s any `async function`s) will be run immediately
+	 * after the script has run. They are included in the `timeout` and `breakOnSigint` scopes in that case.
+	 * Only available for node v14.6+.
 	 * @throws {VMError} If the compiler is unknown.
 	 */
 	constructor(options = {}) {
@@ -646,6 +651,7 @@ class VM extends EventEmitter {
 		} = options;
 		const allowEval = options.eval !== false;
 		const allowWasm = options.wasm !== false;
+		const microtaskMode = options.microtaskMode;
 		const fixAsync = !!options.fixAsync;
 
 		// Early error if sandbox is not an object.
@@ -653,6 +659,10 @@ class VM extends EventEmitter {
 			throw new VMError('Sandbox must be object.');
 		}
 
+		// Early error if microtaskMode is not 'afterEvaluate'.
+		if (microtaskMode && microtaskMode !== 'afterEvaluate') {
+			throw new VMError('microtaskMode must be afterEvaluate');
+		}
 		// Early error if compiler can't be found.
 		const resolvedCompiler = lookupCompiler(compiler);
 
@@ -661,7 +671,8 @@ class VM extends EventEmitter {
 			codeGeneration: {
 				strings: allowEval,
 				wasm: allowWasm
-			}
+			},
+			microtaskMode
 		});
 
 		// Create the bridge between the host and the sandbox.
@@ -751,7 +762,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * Adds all the values to the globals.
-	 * 
+	 *
 	 * @public
 	 * @since v3.9.0
 	 * @param {Object} values - All values that will be added to the globals.
@@ -769,7 +780,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * Set a global value.
-	 * 
+	 *
 	 * @public
 	 * @since v3.9.0
 	 * @param {string} name - The name of the global.
@@ -784,7 +795,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * Get a global value.
-	 * 
+	 *
 	 * @public
 	 * @since v3.9.0
 	 * @param {string} name - The name of the global.
@@ -982,7 +993,7 @@ class NodeVM extends VM {
 	 * Create a new NodeVM instance.<br>
 	 *
 	 * Unlike VM, NodeVM lets you use require same way like in regular node.<br>
-	 * 
+	 *
 	 * However, it does not use the timeout.
 	 *
 	 * @public
@@ -995,9 +1006,13 @@ class NodeVM extends VM {
 	 * Only available for node v10+.
 	 * @param {("inherit"|"redirect"|"off")} [options.console="inherit"] - Sets the behavior of the console in the sandbox.
 	 * <code>inherit</code> to enable console, <code>redirect</code> to redirect to events, <code>off</code> to disable console.
+	 * Only available for node v14.6+.
+	 * @param {string} [options.microtaskMode= undefined] - If set to `afterEvaluate`,
+	 * microtasks (tasks scheduled through `Promise`s any `async function`s) will be run immediately
+	 * after the script has run. They are included in the `timeout` and `breakOnSigint` scopes in that case.
 	 * @param {Object|boolean} [options.require=false] - Allow require inside the sandbox.
 	 * @param {(boolean|string[]|Object)} [options.require.external=false] - true, an array of allowed external modules or an object.
-	 * @param {(string[])} [options.require.external.modules] - Array of allowed external modules. Also supports wildcards, so specifying ['@scope/*-ver-??], 
+	 * @param {(string[])} [options.require.external.modules] - Array of allowed external modules. Also supports wildcards, so specifying ['@scope/*-ver-??],
 	 * for instance, will allow using all modules having a name of the form @scope/something-ver-aa, @scope/other-ver-11, etc.
 	 * @param {boolean} [options.require.external.transitive=false] - Boolean which indicates if transitive dependencies of external modules are allowed.
 	 * @param {string[]} [options.require.builtin=[]] - Array of allowed builtin modules, accepts ["*"] for all.
@@ -1010,12 +1025,12 @@ class NodeVM extends VM {
 	 * @param {resolveCallback} [options.require.resolve] - An additional lookup function in case a module wasn't
 	 * found in one of the traditional node lookup paths.
 	 * @param {boolean} [options.nesting=false] - Allow nesting of VMs.
-	 * @param {("commonjs"|"none")} [options.wrapper="commonjs"] - <code>commonjs</code> to wrap script into CommonJS wrapper, 
+	 * @param {("commonjs"|"none")} [options.wrapper="commonjs"] - <code>commonjs</code> to wrap script into CommonJS wrapper,
 	 * <code>none</code> to retrieve value returned by the script.
 	 * @param {string[]} [options.sourceExtensions=["js"]] - Array of file extensions to treat as source code.
-	 * @param {string[]} [options.argv=[]] - Array of arguments passed to <code>process.argv</code>. 
+	 * @param {string[]} [options.argv=[]] - Array of arguments passed to <code>process.argv</code>.
 	 * This object will not be copied and the script can change this object.
-	 * @param {Object} [options.env={}] - Environment map passed to <code>process.env</code>. 
+	 * @param {Object} [options.env={}] - Environment map passed to <code>process.env</code>.
 	 * This object will not be copied and the script can change this object.
 	 * @throws {VMError} If the compiler is unknown.
 	 */
@@ -1027,7 +1042,7 @@ class NodeVM extends VM {
 			throw new VMError('Sandbox must be object.');
 		}
 
-		super({compiler: options.compiler, eval: options.eval, wasm: options.wasm});
+		super({compiler: options.compiler, eval: options.eval, wasm: options.wasm, microtaskMode: options.microtaskMode});
 
 		// defaults
 		Object.defineProperty(this, 'options', {value: {
@@ -1248,7 +1263,7 @@ class VMError extends Error {
 
 /**
  * Host objects
- * 
+ *
  * @private
  */
 const HOST = {


### PR DESCRIPTION
In Node v14.06, official `vm` module add run-after-evaluate microtask mode (By Anna Henningsen, [PR](https://github.com/nodejs/node/pull/34023))

This allows timeouts to apply to e.g. Promises and async functions from code running inside of vm.Contexts, by giving the Context its own microtasks queue.