### PR TITLE
fix restriction on modifications of objects inherited from builtin modules

### DIFF
--- a/lib/contextify.js
+++ b/lib/contextify.js
@@ -39,7 +39,18 @@ const OPNA = 'Operation not allowed on contextified object.';
 const captureStackTrace = Error.captureStackTrace;
 
 const FROZEN_TRAPS = host.Object.create(null);
-FROZEN_TRAPS.set = (target, key) => false;
+FROZEN_TRAPS.set = (target, key, value, receiver) => {
+	if (target !== receiver) {
+		Object.defineProperty(receiver, key, {
+			value: value,
+			writable: true,
+			enumerable: true,
+			configurable: true
+		});
+		return true;
+	}
+	return false;
+};
 FROZEN_TRAPS.setPrototypeOf = (target, key) => false;
 FROZEN_TRAPS.defineProperty = (target, key) => false;
 FROZEN_TRAPS.deleteProperty = (target, key) => false;


### PR DESCRIPTION
Fixed restriction on modifications of objects inherited from builtin modules as described and based on the suggested solution in the issue https://github.com/patriksimek/vm2/issues/101