### PR TITLE
Frozen object tries to create property on receiver

### DIFF
--- a/lib/contextify.js
+++ b/lib/contextify.js
@@ -44,13 +44,25 @@ const DEBUG = false;
 const OPNA = 'Operation not allowed on contextified object.';
 const captureStackTrace = Error.captureStackTrace;
 
-const FROZEN_TRAPS = host.Object.create(null);
-FROZEN_TRAPS.set = (target, key) => false;
-FROZEN_TRAPS.setPrototypeOf = (target, key) => false;
-FROZEN_TRAPS.defineProperty = (target, key) => false;
-FROZEN_TRAPS.deleteProperty = (target, key) => false;
-FROZEN_TRAPS.isExtensible = (target, key) => false;
-FROZEN_TRAPS.preventExtensions = (target) => false;
+const RETURN_FALSE = () => false;
+
+const FROZEN_TRAPS = {
+	__proto__: null,
+	set(target, key, value, receiver) {
+		return local.Reflect.defineProperty(receiver, key, {
+			__proto__: null,
+			value: value,
+			writable: true,
+			enumerable: true,
+			configurable: true
+		});
+	},
+	setPrototypeOf: RETURN_FALSE,
+	defineProperty: RETURN_FALSE,
+	deleteProperty: RETURN_FALSE,
+	isExtensible: RETURN_FALSE,
+	preventExtensions: RETURN_FALSE
+};
 
 // Map of contextified objects to original objects
 const Contextified = new host.WeakMap();

--- a/test/vm.js
+++ b/test/vm.js
@@ -995,6 +995,9 @@ describe('freeze, protect', () => {
 
 		vm.run('x.c.d = () => { return `---` };');
 		assert.strictEqual(x.c.d(), 'd');
+
+		// Extension of frozen objects should be writeable.
+		assert.strictEqual(vm.run('y = Object.create(x); y.f = 1; y.f'), 1);
 	});
 
 	it('without protect', () => {


### PR DESCRIPTION
This should fix https://github.com/patriksimek/vm2/issues/330. We now try to create the property on the receiver if an frozen object is discovered in the property chain.