### PR TITLE
Fix problem with promise

### DIFF
--- a/lib/fixasync.js
+++ b/lib/fixasync.js
@@ -66,15 +66,18 @@ global.eval = new host.Proxy(eval_, makeCheckFunction('eval'));
 if (Promise) {
 
 	Promise.prototype.then = new host.Proxy(Promise.prototype.then, makeCheckFunction('promise_then'));
-	Contextify.connect(host.Promise.prototype.then, Promise.prototype.then);
+	// This seems not to work, and will produce
+	// UnhandledPromiseRejectionWarning: TypeError: Method Promise.prototype.then called on incompatible receiver [object Object].
+	// This is likely caused since the host.Promise.prototype.then cannot use the VM Proxy object.
+	// Contextify.connect(host.Promise.prototype.then, Promise.prototype.then);
 
 	if (Promise.prototype.finally) {
 		Promise.prototype.finally = new host.Proxy(Promise.prototype.finally, makeCheckFunction('promise_finally'));
-		Contextify.connect(host.Promise.prototype.finally, Promise.prototype.finally);
+		// Contextify.connect(host.Promise.prototype.finally, Promise.prototype.finally);
 	}
 	if (Promise.prototype.catch) {
 		Promise.prototype.catch = new host.Proxy(Promise.prototype.catch, makeCheckFunction('promise_catch'));
-		Contextify.connect(host.Promise.prototype.catch, Promise.prototype.catch);
+		// Contextify.connect(host.Promise.prototype.catch, Promise.prototype.catch);
 	}
 
 }


### PR DESCRIPTION
Should fix https://github.com/patriksimek/vm2/issues/368.
The sandbox tried to use the `then` method from the specific environment, however, this `then` might not work with the proxy of a promise from the other environment. Therefore the change was reverted.