### PR TITLE
Fix import keyword detection

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -564,7 +564,7 @@ function makeCheckHook(checkAsync, checkImport) {
 				args = args.map(arg => `${arg}`);
 			}
 			const hasAsync = checkAsync && args.findIndex(arg => /\basync\b/.test(arg)) !== -1;
-			const hasImport = checkImport && args.findIndex(arg => /\bimport\b/.test(arg)) !== -1;
+			const hasImport = checkImport && args.findIndex(arg => /\bimport\s*\(/.test(arg)) !== -1;
 			if (!hasAsync && !hasImport) return args;
 			const mapped = args.map(arg => {
 				if (hasAsync) arg = arg.replace(/async/g, 'a\\u0073ync');

--- a/test/vm.js
+++ b/test/vm.js
@@ -917,6 +917,20 @@ describe('VM', () => {
 			assert.throws(()=>vm2.run(`
 				const process = import('oops!').constructor.constructor('return process')();
 			`), /VMError: Dynamic Import not supported/);
+
+			assert.throws(()=>vm2.run(`
+				const process = import ('oops!').constructor.constructor('return process')();
+			`), /VMError: Dynamic Import not supported/);
+
+			assert.doesNotThrow(()=>vm2.run(`
+				let a = {import: 1}
+				let b = {import : {"import": 2}};
+				let c = { import : 1};
+				let d = a.import;
+				let e = a. import;
+				let f = a.import-1;
+				let g = a.import.import;
+			`));
 		});
 	}
 


### PR DESCRIPTION
Currently, there is quite a lot of false positives when detecting an import keyword. As we're only trying to catch the dynamic import, I'd suggest updating the regexp accordingly.

@XmiliaH May I kindly ask you to get your eyes on that before we merge as I might be overlooking something. Thank you.