### PR TITLE
Issue #70 - Fix webpack incompatibility

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1335,7 +1335,7 @@ class VMError extends Error {
  */
 const HOST = {
 	version: parseInt(process.versions.node.split('.')[0]),
-	require,
+	require: eval(require),
 	process,
 	console,
 	setTimeout,


### PR DESCRIPTION
Add eval to host require statement to allow webpack to statically extract dependencies

This fix, allows webpack to be able to statically extract dependencies. This is the main hurdle when using webpack with this library as webpack emits errors and ends up repacing good code with bad (see: https://github.com/patriksimek/vm2/issues/70#issuecomment-297601837).

Once webpack is able to correctly compile this code, you can use a standard webpack config with the target set to `node` to be able to compile this into a usable library. 

Example working webpack config:

```javascript
const path = require('path');

module.exports = {
  entry: './src/index.ts',
  devtool: 'eval-source-map',
  module: {
    rules: [
      {
        test: /\.tsx?$/,
        use: 'ts-loader',
        exclude: /node_modules/,
      }
    ],
  },
  target: "node",
  externals: {
   coffeeScript: 'coffee-script',
   vm2: 'vm2'
  },
  resolve: {
    extensions: ['.tsx', '.ts', '.js'],
  },
  output: {
    filename: 'bundle.js',
    path: path.resolve(__dirname, 'lib'),
    library: {
      name: 'your-library-name',
      type: 'umd2'
    },
    globalObject: 'this',
  },
  optimization: {
    minimize: false
  },
  mode: 'development',
};
```