### PR TITLE
Provide require.resolve for NodeVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Unlike `VM`, `NodeVM` lets you require modules same way like in regular Node's c
 * `require.context` - `host` (default) to require modules in host and proxy them to sandbox. `sandbox` to load, compile and require modules in sandbox. Builtin modules except `events` always required in host and proxied to sandbox.
 * `require.import` - Array of modules to be loaded into NodeVM on start.
 * `require.resolve` - An additional lookup function in case a module wasn't found in one of the traditional node lookup paths.
+* `resolve` - Disable (`false`, default), enable (`true`) or override (a function) the behavior of `require.resolve`.
 * `nesting` - `true` to enable VMs nesting (default: `false`).
 * `wrapper` - `commonjs` (default) to wrap script into CommonJS wrapper, `none` to retrieve value returned by the script.
 * `argv` - Array to be passed to `process.argv`.

--- a/lib/main.js
+++ b/lib/main.js
@@ -1070,6 +1070,7 @@ class NodeVM extends VM {
 	 * @param {resolveCallback} [options.require.resolve] - An additional lookup function in case a module wasn't
 	 * found in one of the traditional node lookup paths.
 	 * @param {boolean} [options.nesting=false] - Allow nesting of VMs.
+	 * @param {boolean|function} [options.resolve] - Enable, disable or override the require.resolve behavior.
 	 * @param {("commonjs"|"none")} [options.wrapper="commonjs"] - <code>commonjs</code> to wrap script into CommonJS wrapper, 
 	 * <code>none</code> to retrieve value returned by the script.
 	 * @param {string[]} [options.sourceExtensions=["js"]] - Array of file extensions to treat as source code.

--- a/lib/main.js
+++ b/lib/main.js
@@ -1094,6 +1094,7 @@ class NodeVM extends VM {
 		Object.defineProperty(this, 'options', {value: {
 			console: options.console || 'inherit',
 			require: options.require || false,
+			resolve: options.resolve || false,
 			nesting: options.nesting || false,
 			wrapper: options.wrapper || 'commonjs',
 			sourceExtensions: options.sourceExtensions || ['js'],

--- a/lib/main.js
+++ b/lib/main.js
@@ -38,7 +38,7 @@ const MODULE_SUFFIX = '\n});';
 
 /**
  * Load a script from a file and compile it.
- * 
+ *
  * @private
  * @param {string} filename - File to load and compile to a script.
  * @param {string} prefix - Prefix for the script.
@@ -56,7 +56,7 @@ function loadAndCompileScript(filename, prefix, suffix) {
 
 /**
  * Cache where we can cache some things
- * 
+ *
  * @private
  * @property {?compileCallback} coffeeScriptCompiler - The coffee script compiler or null if not yet used.
  * @property {?Object} timeoutContext - The context used for the timeout functionality of null if not yet used.
@@ -84,7 +84,7 @@ const CACHE = {
 
 /**
  * Default run options for vm.Script.runInContext
- * 
+ *
  * @private
  */
 const DEFAULT_RUN_OPTIONS = {displayErrors: false, importModuleDynamically};
@@ -92,7 +92,7 @@ const DEFAULT_RUN_OPTIONS = {displayErrors: false, importModuleDynamically};
 /**
  * Returns the cached coffee script compiler or loads it
  * if it is not found in the cache.
- * 
+ *
  * @private
  * @return {compileCallback} The coffee script compiler.
  * @throws {VMError} If the coffee-script module can't be found.
@@ -113,7 +113,7 @@ function getCoffeeScriptCompiler() {
 
 /**
  * The JavaScript compiler, just a identity function.
- * 
+ *
  * @private
  * @type {compileCallback}
  * @param {string} code - The JavaScript code.
@@ -126,7 +126,7 @@ function jsCompiler(code, filename) {
 
 /**
  * Look up the compiler for a specific name.
- * 
+ *
  * @private
  * @param {(string|compileCallback)} compiler - A compile callback or the name of the compiler.
  * @return {compileCallback} The resolved compiler.
@@ -152,7 +152,7 @@ function lookupCompiler(compiler) {
 
 /**
  * Remove the shebang from source code.
- * 
+ *
  * @private
  * @param {string} code - Code from which to remove the shebang.
  * @return {string} code without the shebang.
@@ -172,7 +172,7 @@ class VMScript {
 	/**
 	 * The script code with wrapping. If set will invalidate the cache.<br>
 	 * Writable only for backwards compatibility.
-	 * 
+	 *
 	 * @public
 	 * @readonly
 	 * @member {string} code
@@ -181,7 +181,7 @@ class VMScript {
 
 	/**
 	 * The filename used for this script.
-	 * 
+	 *
 	 * @public
 	 * @readonly
 	 * @since v3.9.0
@@ -191,7 +191,7 @@ class VMScript {
 
 	/**
 	 * The line offset use for stack traces.
-	 * 
+	 *
 	 * @public
 	 * @readonly
 	 * @since v3.9.0
@@ -201,7 +201,7 @@ class VMScript {
 
 	/**
 	 * The column offset use for stack traces.
-	 * 
+	 *
 	 * @public
 	 * @readonly
 	 * @since v3.9.0
@@ -211,7 +211,7 @@ class VMScript {
 
 	/**
 	 * The compiler to use to get the JavaScript code.
-	 * 
+	 *
 	 * @public
 	 * @readonly
 	 * @since v3.9.0
@@ -221,7 +221,7 @@ class VMScript {
 
 	/**
 	 * The prefix for the script.
-	 * 
+	 *
 	 * @private
 	 * @member {string} _prefix
 	 * @memberOf VMScript#
@@ -229,7 +229,7 @@ class VMScript {
 
 	/**
 	 * The suffix for the script.
-	 * 
+	 *
 	 * @private
 	 * @member {string} _suffix
 	 * @memberOf VMScript#
@@ -237,7 +237,7 @@ class VMScript {
 
 	/**
 	 * The compiled vm.Script for the VM or if not compiled <code>null</code>.
-	 * 
+	 *
 	 * @private
 	 * @member {?vm.Script} _compiledVM
 	 * @memberOf VMScript#
@@ -245,7 +245,7 @@ class VMScript {
 
 	/**
 	 * The compiled vm.Script for the NodeVM or if not compiled <code>null</code>.
-	 * 
+	 *
 	 * @private
 	 * @member {?vm.Script} _compiledNodeVM
 	 * @memberOf VMScript#
@@ -253,7 +253,7 @@ class VMScript {
 
 	/**
 	 * The compiled vm.Script for the NodeVM in strict mode or if not compiled <code>null</code>.
-	 * 
+	 *
 	 * @private
 	 * @member {?vm.Script} _compiledNodeVMStrict
 	 * @memberOf VMScript#
@@ -261,7 +261,7 @@ class VMScript {
 
 	/**
 	 * The resolved compiler to use to get the JavaScript code.
-	 * 
+	 *
 	 * @private
 	 * @readonly
 	 * @member {compileCallback} _compiler
@@ -270,7 +270,7 @@ class VMScript {
 
 	/**
 	 * The script to run without wrapping.
-	 * 
+	 *
 	 * @private
 	 * @member {string} _code
 	 * @memberOf VMScript#
@@ -423,7 +423,7 @@ class VMScript {
 
 	/**
 	 * Get the compiled code.
-	 * 
+	 *
 	 * @private
 	 * @return {string} The code.
 	 */
@@ -436,7 +436,7 @@ class VMScript {
 
 	/**
 	 * Compiles this script to a vm.Script.
-	 * 
+	 *
 	 * @private
 	 * @param {string} prefix - JavaScript code that will be used as prefix.
 	 * @param {string} suffix - JavaScript code that will be used as suffix.
@@ -455,7 +455,7 @@ class VMScript {
 
 	/**
 	 * Will return the cached version of the script intended for VM or compile it.
-	 * 
+	 *
 	 * @private
 	 * @return {vm.Script} The compiled script
 	 * @throws {SyntaxError} If there is a syntax error in the script.
@@ -470,7 +470,7 @@ class VMScript {
 
 	/**
 	 * Will return the cached version of the script intended for NodeVM or compile it.
-	 * 
+	 *
 	 * @private
 	 * @return {vm.Script} The compiled script
 	 * @throws {SyntaxError} If there is a syntax error in the script.
@@ -485,7 +485,7 @@ class VMScript {
 
 	/**
 	 * Will return the cached version of the script intended for NodeVM in strict mode or compile it.
-	 * 
+	 *
 	 * @private
 	 * @return {vm.Script} The compiled script
 	 * @throws {SyntaxError} If there is a syntax error in the script.
@@ -501,20 +501,20 @@ class VMScript {
 }
 
 /**
- * 
+ *
  * This callback will be called and has a specific time to finish.<br>
  * No parameters will be supplied.<br>
  * If parameters are required, use a closure.
- * 
+ *
  * @private
  * @callback runWithTimeout
- * @return {*} 
- * 
+ * @return {*}
+ *
  */
 
 /**
  * Run a function with a specific timeout.
- * 
+ *
  * @private
  * @param {runWithTimeout} fn - Function to run with the specific timeout.
  * @param {number} timeout - The amount of time to give the function to finish.
@@ -629,7 +629,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * The compiler to use to get the JavaScript code.
-	 * 
+	 *
 	 * @public
 	 * @readonly
 	 * @since v3.9.0
@@ -639,7 +639,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * The context for this sandbox.
-	 * 
+	 *
 	 * @private
 	 * @readonly
 	 * @member {Object} _context
@@ -648,7 +648,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * The internal methods for this sandbox.
-	 * 
+	 *
 	 * @private
 	 * @readonly
 	 * @member {{Contextify: Object, Decontextify: Object, Buffer: Object, sandbox:Object}} _internal
@@ -657,7 +657,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * The resolved compiler to use to get the JavaScript code.
-	 * 
+	 *
 	 * @private
 	 * @readonly
 	 * @member {compileCallback} _compiler
@@ -666,7 +666,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * The hook called when some events occurs.
-	 * 
+	 *
 	 * @private
 	 * @readonly
 	 * @since v3.9.2
@@ -809,7 +809,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * Adds all the values to the globals.
-	 * 
+	 *
 	 * @public
 	 * @since v3.9.0
 	 * @param {Object} values - All values that will be added to the globals.
@@ -827,7 +827,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * Set a global value.
-	 * 
+	 *
 	 * @public
 	 * @since v3.9.0
 	 * @param {string} name - The name of the global.
@@ -842,7 +842,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * Get a global value.
-	 * 
+	 *
 	 * @public
 	 * @since v3.9.0
 	 * @param {string} name - The name of the global.
@@ -1042,7 +1042,7 @@ class NodeVM extends VM {
 	 * Create a new NodeVM instance.<br>
 	 *
 	 * Unlike VM, NodeVM lets you use require same way like in regular node.<br>
-	 * 
+	 *
 	 * However, it does not use the timeout.
 	 *
 	 * @public
@@ -1057,7 +1057,7 @@ class NodeVM extends VM {
 	 * <code>inherit</code> to enable console, <code>redirect</code> to redirect to events, <code>off</code> to disable console.
 	 * @param {Object|boolean} [options.require=false] - Allow require inside the sandbox.
 	 * @param {(boolean|string[]|Object)} [options.require.external=false] - true, an array of allowed external modules or an object.
-	 * @param {(string[])} [options.require.external.modules] - Array of allowed external modules. Also supports wildcards, so specifying ['@scope/*-ver-??], 
+	 * @param {(string[])} [options.require.external.modules] - Array of allowed external modules. Also supports wildcards, so specifying ['@scope/*-ver-??],
 	 * for instance, will allow using all modules having a name of the form @scope/something-ver-aa, @scope/other-ver-11, etc.
 	 * @param {boolean} [options.require.external.transitive=false] - Boolean which indicates if transitive dependencies of external modules are allowed.
 	 * @param {string[]} [options.require.builtin=[]] - Array of allowed builtin modules, accepts ["*"] for all.
@@ -1070,12 +1070,12 @@ class NodeVM extends VM {
 	 * @param {resolveCallback} [options.require.resolve] - An additional lookup function in case a module wasn't
 	 * found in one of the traditional node lookup paths.
 	 * @param {boolean} [options.nesting=false] - Allow nesting of VMs.
-	 * @param {("commonjs"|"none")} [options.wrapper="commonjs"] - <code>commonjs</code> to wrap script into CommonJS wrapper, 
+	 * @param {("commonjs"|"none")} [options.wrapper="commonjs"] - <code>commonjs</code> to wrap script into CommonJS wrapper,
 	 * <code>none</code> to retrieve value returned by the script.
 	 * @param {string[]} [options.sourceExtensions=["js"]] - Array of file extensions to treat as source code.
-	 * @param {string[]} [options.argv=[]] - Array of arguments passed to <code>process.argv</code>. 
+	 * @param {string[]} [options.argv=[]] - Array of arguments passed to <code>process.argv</code>.
 	 * This object will not be copied and the script can change this object.
-	 * @param {Object} [options.env={}] - Environment map passed to <code>process.env</code>. 
+	 * @param {Object} [options.env={}] - Environment map passed to <code>process.env</code>.
 	 * This object will not be copied and the script can change this object.
 	 * @param {boolean} [options.strict=false] - If modules should be loaded in strict mode.
 	 * @throws {VMError} If the compiler is unknown.
@@ -1094,6 +1094,7 @@ class NodeVM extends VM {
 		Object.defineProperty(this, 'options', {value: {
 			console: options.console || 'inherit',
 			require: options.require || false,
+			resolve: options.resolve || false,
 			nesting: options.nesting || false,
 			wrapper: options.wrapper || 'commonjs',
 			sourceExtensions: options.sourceExtensions || ['js'],
@@ -1330,7 +1331,7 @@ class VMError extends Error {
 
 /**
  * Host objects
- * 
+ *
  * @private
  */
 const HOST = {

--- a/lib/main.js
+++ b/lib/main.js
@@ -38,7 +38,7 @@ const MODULE_SUFFIX = '\n});';
 
 /**
  * Load a script from a file and compile it.
- *
+ * 
  * @private
  * @param {string} filename - File to load and compile to a script.
  * @param {string} prefix - Prefix for the script.
@@ -56,7 +56,7 @@ function loadAndCompileScript(filename, prefix, suffix) {
 
 /**
  * Cache where we can cache some things
- *
+ * 
  * @private
  * @property {?compileCallback} coffeeScriptCompiler - The coffee script compiler or null if not yet used.
  * @property {?Object} timeoutContext - The context used for the timeout functionality of null if not yet used.
@@ -84,7 +84,7 @@ const CACHE = {
 
 /**
  * Default run options for vm.Script.runInContext
- *
+ * 
  * @private
  */
 const DEFAULT_RUN_OPTIONS = {displayErrors: false, importModuleDynamically};
@@ -92,7 +92,7 @@ const DEFAULT_RUN_OPTIONS = {displayErrors: false, importModuleDynamically};
 /**
  * Returns the cached coffee script compiler or loads it
  * if it is not found in the cache.
- *
+ * 
  * @private
  * @return {compileCallback} The coffee script compiler.
  * @throws {VMError} If the coffee-script module can't be found.
@@ -113,7 +113,7 @@ function getCoffeeScriptCompiler() {
 
 /**
  * The JavaScript compiler, just a identity function.
- *
+ * 
  * @private
  * @type {compileCallback}
  * @param {string} code - The JavaScript code.
@@ -126,7 +126,7 @@ function jsCompiler(code, filename) {
 
 /**
  * Look up the compiler for a specific name.
- *
+ * 
  * @private
  * @param {(string|compileCallback)} compiler - A compile callback or the name of the compiler.
  * @return {compileCallback} The resolved compiler.
@@ -152,7 +152,7 @@ function lookupCompiler(compiler) {
 
 /**
  * Remove the shebang from source code.
- *
+ * 
  * @private
  * @param {string} code - Code from which to remove the shebang.
  * @return {string} code without the shebang.
@@ -172,7 +172,7 @@ class VMScript {
 	/**
 	 * The script code with wrapping. If set will invalidate the cache.<br>
 	 * Writable only for backwards compatibility.
-	 *
+	 * 
 	 * @public
 	 * @readonly
 	 * @member {string} code
@@ -181,7 +181,7 @@ class VMScript {
 
 	/**
 	 * The filename used for this script.
-	 *
+	 * 
 	 * @public
 	 * @readonly
 	 * @since v3.9.0
@@ -191,7 +191,7 @@ class VMScript {
 
 	/**
 	 * The line offset use for stack traces.
-	 *
+	 * 
 	 * @public
 	 * @readonly
 	 * @since v3.9.0
@@ -201,7 +201,7 @@ class VMScript {
 
 	/**
 	 * The column offset use for stack traces.
-	 *
+	 * 
 	 * @public
 	 * @readonly
 	 * @since v3.9.0
@@ -211,7 +211,7 @@ class VMScript {
 
 	/**
 	 * The compiler to use to get the JavaScript code.
-	 *
+	 * 
 	 * @public
 	 * @readonly
 	 * @since v3.9.0
@@ -221,7 +221,7 @@ class VMScript {
 
 	/**
 	 * The prefix for the script.
-	 *
+	 * 
 	 * @private
 	 * @member {string} _prefix
 	 * @memberOf VMScript#
@@ -229,7 +229,7 @@ class VMScript {
 
 	/**
 	 * The suffix for the script.
-	 *
+	 * 
 	 * @private
 	 * @member {string} _suffix
 	 * @memberOf VMScript#
@@ -237,7 +237,7 @@ class VMScript {
 
 	/**
 	 * The compiled vm.Script for the VM or if not compiled <code>null</code>.
-	 *
+	 * 
 	 * @private
 	 * @member {?vm.Script} _compiledVM
 	 * @memberOf VMScript#
@@ -245,7 +245,7 @@ class VMScript {
 
 	/**
 	 * The compiled vm.Script for the NodeVM or if not compiled <code>null</code>.
-	 *
+	 * 
 	 * @private
 	 * @member {?vm.Script} _compiledNodeVM
 	 * @memberOf VMScript#
@@ -253,7 +253,7 @@ class VMScript {
 
 	/**
 	 * The compiled vm.Script for the NodeVM in strict mode or if not compiled <code>null</code>.
-	 *
+	 * 
 	 * @private
 	 * @member {?vm.Script} _compiledNodeVMStrict
 	 * @memberOf VMScript#
@@ -261,7 +261,7 @@ class VMScript {
 
 	/**
 	 * The resolved compiler to use to get the JavaScript code.
-	 *
+	 * 
 	 * @private
 	 * @readonly
 	 * @member {compileCallback} _compiler
@@ -270,7 +270,7 @@ class VMScript {
 
 	/**
 	 * The script to run without wrapping.
-	 *
+	 * 
 	 * @private
 	 * @member {string} _code
 	 * @memberOf VMScript#
@@ -423,7 +423,7 @@ class VMScript {
 
 	/**
 	 * Get the compiled code.
-	 *
+	 * 
 	 * @private
 	 * @return {string} The code.
 	 */
@@ -436,7 +436,7 @@ class VMScript {
 
 	/**
 	 * Compiles this script to a vm.Script.
-	 *
+	 * 
 	 * @private
 	 * @param {string} prefix - JavaScript code that will be used as prefix.
 	 * @param {string} suffix - JavaScript code that will be used as suffix.
@@ -455,7 +455,7 @@ class VMScript {
 
 	/**
 	 * Will return the cached version of the script intended for VM or compile it.
-	 *
+	 * 
 	 * @private
 	 * @return {vm.Script} The compiled script
 	 * @throws {SyntaxError} If there is a syntax error in the script.
@@ -470,7 +470,7 @@ class VMScript {
 
 	/**
 	 * Will return the cached version of the script intended for NodeVM or compile it.
-	 *
+	 * 
 	 * @private
 	 * @return {vm.Script} The compiled script
 	 * @throws {SyntaxError} If there is a syntax error in the script.
@@ -485,7 +485,7 @@ class VMScript {
 
 	/**
 	 * Will return the cached version of the script intended for NodeVM in strict mode or compile it.
-	 *
+	 * 
 	 * @private
 	 * @return {vm.Script} The compiled script
 	 * @throws {SyntaxError} If there is a syntax error in the script.
@@ -501,20 +501,20 @@ class VMScript {
 }
 
 /**
- *
+ * 
  * This callback will be called and has a specific time to finish.<br>
  * No parameters will be supplied.<br>
  * If parameters are required, use a closure.
- *
+ * 
  * @private
  * @callback runWithTimeout
- * @return {*}
- *
+ * @return {*} 
+ * 
  */
 
 /**
  * Run a function with a specific timeout.
- *
+ * 
  * @private
  * @param {runWithTimeout} fn - Function to run with the specific timeout.
  * @param {number} timeout - The amount of time to give the function to finish.
@@ -629,7 +629,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * The compiler to use to get the JavaScript code.
-	 *
+	 * 
 	 * @public
 	 * @readonly
 	 * @since v3.9.0
@@ -639,7 +639,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * The context for this sandbox.
-	 *
+	 * 
 	 * @private
 	 * @readonly
 	 * @member {Object} _context
@@ -648,7 +648,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * The internal methods for this sandbox.
-	 *
+	 * 
 	 * @private
 	 * @readonly
 	 * @member {{Contextify: Object, Decontextify: Object, Buffer: Object, sandbox:Object}} _internal
@@ -657,7 +657,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * The resolved compiler to use to get the JavaScript code.
-	 *
+	 * 
 	 * @private
 	 * @readonly
 	 * @member {compileCallback} _compiler
@@ -666,7 +666,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * The hook called when some events occurs.
-	 *
+	 * 
 	 * @private
 	 * @readonly
 	 * @since v3.9.2
@@ -809,7 +809,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * Adds all the values to the globals.
-	 *
+	 * 
 	 * @public
 	 * @since v3.9.0
 	 * @param {Object} values - All values that will be added to the globals.
@@ -827,7 +827,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * Set a global value.
-	 *
+	 * 
 	 * @public
 	 * @since v3.9.0
 	 * @param {string} name - The name of the global.
@@ -842,7 +842,7 @@ class VM extends EventEmitter {
 
 	/**
 	 * Get a global value.
-	 *
+	 * 
 	 * @public
 	 * @since v3.9.0
 	 * @param {string} name - The name of the global.
@@ -1042,7 +1042,7 @@ class NodeVM extends VM {
 	 * Create a new NodeVM instance.<br>
 	 *
 	 * Unlike VM, NodeVM lets you use require same way like in regular node.<br>
-	 *
+	 * 
 	 * However, it does not use the timeout.
 	 *
 	 * @public
@@ -1057,7 +1057,7 @@ class NodeVM extends VM {
 	 * <code>inherit</code> to enable console, <code>redirect</code> to redirect to events, <code>off</code> to disable console.
 	 * @param {Object|boolean} [options.require=false] - Allow require inside the sandbox.
 	 * @param {(boolean|string[]|Object)} [options.require.external=false] - true, an array of allowed external modules or an object.
-	 * @param {(string[])} [options.require.external.modules] - Array of allowed external modules. Also supports wildcards, so specifying ['@scope/*-ver-??],
+	 * @param {(string[])} [options.require.external.modules] - Array of allowed external modules. Also supports wildcards, so specifying ['@scope/*-ver-??], 
 	 * for instance, will allow using all modules having a name of the form @scope/something-ver-aa, @scope/other-ver-11, etc.
 	 * @param {boolean} [options.require.external.transitive=false] - Boolean which indicates if transitive dependencies of external modules are allowed.
 	 * @param {string[]} [options.require.builtin=[]] - Array of allowed builtin modules, accepts ["*"] for all.
@@ -1070,12 +1070,12 @@ class NodeVM extends VM {
 	 * @param {resolveCallback} [options.require.resolve] - An additional lookup function in case a module wasn't
 	 * found in one of the traditional node lookup paths.
 	 * @param {boolean} [options.nesting=false] - Allow nesting of VMs.
-	 * @param {("commonjs"|"none")} [options.wrapper="commonjs"] - <code>commonjs</code> to wrap script into CommonJS wrapper,
+	 * @param {("commonjs"|"none")} [options.wrapper="commonjs"] - <code>commonjs</code> to wrap script into CommonJS wrapper, 
 	 * <code>none</code> to retrieve value returned by the script.
 	 * @param {string[]} [options.sourceExtensions=["js"]] - Array of file extensions to treat as source code.
-	 * @param {string[]} [options.argv=[]] - Array of arguments passed to <code>process.argv</code>.
+	 * @param {string[]} [options.argv=[]] - Array of arguments passed to <code>process.argv</code>. 
 	 * This object will not be copied and the script can change this object.
-	 * @param {Object} [options.env={}] - Environment map passed to <code>process.env</code>.
+	 * @param {Object} [options.env={}] - Environment map passed to <code>process.env</code>. 
 	 * This object will not be copied and the script can change this object.
 	 * @param {boolean} [options.strict=false] - If modules should be loaded in strict mode.
 	 * @throws {VMError} If the compiler is unknown.
@@ -1094,7 +1094,6 @@ class NodeVM extends VM {
 		Object.defineProperty(this, 'options', {value: {
 			console: options.console || 'inherit',
 			require: options.require || false,
-			resolve: options.resolve || false,
 			nesting: options.nesting || false,
 			wrapper: options.wrapper || 'commonjs',
 			sourceExtensions: options.sourceExtensions || ['js'],
@@ -1331,7 +1330,7 @@ class VMError extends Error {
 
 /**
  * Host objects
- *
+ * 
  * @private
  */
 const HOST = {

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -435,7 +435,6 @@ return ((vm, host) => {
 				throw Contextify.value(e);
 			}
 
-
 			throw new VMError(`Failed to resolve '${request}': Invalid resolve option.`, 'ELOADFAIL');
 		};
 

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -417,35 +417,26 @@ return ((vm, host) => {
 		};
 
 		_require.resolve = (request, options) => {
-			let resolveOption;
-			try {
-				const optionsObj = vm.options;
-				if (optionsObj.nesting && moduleName === 'vm2') {
-					return {VM: Contextify.readonly(host.VM), NodeVM: Contextify.readonly(host.NodeVM)};
-				}
-				resolveOption = optionsObj.resolve;
-			} catch (e) {
-				throw Contextify.value(e);
-			}
+			const resolveOption = vm.options.resolve;
 
-			if (!resolveOption) throw new VMError(`${vm.options.resolve} Access denied to resolve '${request}'`, 'EDENIED');
+			if (!resolveOption) throw new VMError(`Access denied to resolve '${request}'`, 'EDENIED');
 			if (request == null) throw new VMError("Module '' not found.", 'ENOTFOUND');
-			if (typeof request !== 'string') throw new VMError(`Invalid module name '${moduleName}'`, 'EINVALIDNAME');
+			if (typeof request !== 'string') throw new VMError(`Invalid module name '${request}'`, 'EINVALIDNAME');
 
 			try {
 				if (resolveOption === true) {
-					return Contextify.readonly(host.require.resolve(request, options))
+					return Contextify.readonly(host.require.resolve(request, options));
 				}
 
 				if (typeof resolveOption === 'function') {
-					return Contextify.readonly(resolveOption(request, options))
+					return Contextify.readonly(resolveOption(request, options));
 				}
 			} catch (e) {
 				throw Contextify.value(e);
 			}
 
 
-			throw new VMError(`Failed to resolve '${request}': Invalid resolve option.`, 'ELOADFAIL')
+			throw new VMError(`Failed to resolve '${request}': Invalid resolve option.`, 'ELOADFAIL');
 		};
 
 		return _require;

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -416,6 +416,38 @@ return ((vm, host) => {
 			throw new VMError(`Failed to load '${moduleName}': Unknown type.`, 'ELOADFAIL');
 		};
 
+		_require.resolve = (request, options) => {
+			let resolveOption;
+			try {
+				const optionsObj = vm.options;
+				if (optionsObj.nesting && moduleName === 'vm2') {
+					return {VM: Contextify.readonly(host.VM), NodeVM: Contextify.readonly(host.NodeVM)};
+				}
+				resolveOption = optionsObj.resolve;
+			} catch (e) {
+				throw Contextify.value(e);
+			}
+
+			if (!resolveOption) throw new VMError(`${vm.options.resolve} Access denied to resolve '${request}'`, 'EDENIED');
+			if (request == null) throw new VMError("Module '' not found.", 'ENOTFOUND');
+			if (typeof request !== 'string') throw new VMError(`Invalid module name '${moduleName}'`, 'EINVALIDNAME');
+
+			try {
+				if (resolveOption === true) {
+					return Contextify.readonly(host.require.resolve(request, options))
+				}
+
+				if (typeof resolveOption === 'function') {
+					return Contextify.readonly(resolveOption(request, options))
+				}
+			} catch (e) {
+				throw Contextify.value(e);
+			}
+
+
+			throw new VMError(`Failed to resolve '${request}': Invalid resolve option.`, 'ELOADFAIL')
+		};
+
 		return _require;
 	};
 

--- a/test/nodevm.js
+++ b/test/nodevm.js
@@ -392,6 +392,29 @@ describe('modules', () => {
 
 	});
 
+	it('disabled require resolve', () => {
+		const vm = new NodeVM;
+
+		assert.throws(() => vm.run("require.resolve('fs')"), /Access denied to resolve 'fs'/);
+	});
+
+	it('enable require resolve', () => {
+		const vm = new NodeVM({ resolve: true });
+
+		assert.strictEqual(vm.run("module.exports = require.resolve('fs')"), 'fs');
+	});
+
+	it('mock require resolve', () => {
+		const vm = new NodeVM({
+			resolve: (module, options) => {
+				return (module === 'path') ? require.resolve('path') : 'Nice try!';
+			}
+		});
+
+		assert.strictEqual(vm.run("module.exports = require.resolve('fs')"), 'Nice try!');
+		assert.strictEqual(vm.run("module.exports = require.resolve('path')"), 'path');
+	});
+
 	if (NODE_VERSION < 12) {
 		// Doesn't work under Node 12, fix pending
 		it('native event emitter', done => {


### PR DESCRIPTION
I was writing a project with vm2 to run untrusted code but one of them was using `require.resolve` which was not provided.
First thing I did was to modify the source of the library but this is annoying to do for each project, so here's a pull request to make it a feature directly in vm2.

This feature can be configured:
* With `false` it will throw a VMError (EDENIED).
* With `true` it will forward the arguments to the real `require.resolve` function.
* With a function we can override the behavior of `require.resolve`.

PS: The option is not inside the `require` option object because an option `resolve` already existed and I didn't know how to name it to avoid confusion.