### PR TITLE
Fix custom resolver type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ export interface VMRequire {
   /** Collection of mock modules (both external or builtin). */
   mock?: any;
   /* An additional lookup function in case a module wasn't found in one of the traditional node lookup paths. */
-  resolve?: (moduleName: string, parentDirname: string) => string;
+  resolve?: (moduleName: string, parentDirname: string) => string | undefined;
   /** Custom require to require host and built-in modules. */
   customRequire?: (id: string) => any;
 }


### PR DESCRIPTION
The custom resolver is allowed to return undefined (really, any falsy value) if a module is not found, but this type definition requires it to return a string. This fixes the definition to allow undefined.