### PR TITLE
Added function typecheck to the thisOtherHasOwnProperty check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v3.9.7 (TBD)
+-------------------
+[fix] Add function typecheck for arguments, caller, and callee property check (GeoffRen)  
+
 v3.9.7 (2022-02-10)
 -------------------
 [fix] Allow relative require from base script  

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -431,7 +431,9 @@ function createBridge(otherInit, registerProxy) {
 				case 'arguments':
 				case 'caller':
 				case 'callee':
-					if (thisOtherHasOwnProperty(object, key)) throw thisThrowCallerCalleeArgumentsAccess(key);
+					if (thisOtherHasOwnProperty(object, key) && typeof object === 'function') {
+						throw thisThrowCallerCalleeArgumentsAccess(key);
+					}
 					break;
 			}
 			let ret; // @other(unsafe)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vm2",
-  "version": "3.9.5",
+  "version": "3.9.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vm2",
-      "version": "3.9.5",
+      "version": "3.9.7",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.7.0",


### PR DESCRIPTION
Added function typecheck to the thisOtherHasOwnProperty check for the 'arguments', 'caller', and 'callee' properties. Without the typecheck, an error will be thrown when non functions validly access properties named 'arguments', 'caller', and/or 'callee'.