### PR TITLE
Add uptime

### DIFF
--- a/lib/setup-node-sandbox.js
+++ b/lib/setup-node-sandbox.js
@@ -330,6 +330,8 @@ function process() {
 	return this;
 }
 
+const baseUptime = localProcess.uptime();
+
 // FIXME wrong class structure
 global.process = {
 	__proto__: process.prototype,
@@ -353,6 +355,9 @@ global.process = {
 	},
 	hrtime: function hrtime(time) {
 		return localProcess.hrtime(time);
+	},
+	uptime: function uptime() {
+		return localProcess.uptime() - baseUptime;
 	},
 	cwd: function cwd() {
 		return localProcess.cwd();


### PR DESCRIPTION
Add `process.uptime` to the NodeVM sandbox. The uptime is measured from the point the NodeVM is constructed. This should fix https://github.com/patriksimek/vm2/issues/424.