### PR TITLE
Fix 485

### DIFF
--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -103,6 +103,7 @@ function transformer(args, body, isAsync, isGenerator, filename) {
 	const TO_RIGHT = 100;
 
 	let internStateValiable = undefined;
+	let tmpname = "VM2_INTERNAL_TMPNAME";
 
 	acornWalkFull(ast, (node, state, type) => {
 		if (type === 'Function') {
@@ -112,15 +113,30 @@ function transformer(args, body, isAsync, isGenerator, filename) {
 		if (nodeType === 'CatchClause') {
 			const param = node.param;
 			if (param) {
-				const name = assertType(param, 'Identifier').name;
-				const cBody = assertType(node.body, 'BlockStatement');
-				if (cBody.body.length > 0) {
+				if (param.type === 'ObjectPattern') {
 					insertions.push({
 						__proto__: null,
-						pos: cBody.body[0].start,
-						order: TO_LEFT,
-						code: `${name}=${INTERNAL_STATE_NAME}.handleException(${name});`
+						pos: node.start,
+						order: TO_RIGHT,
+						code: `catch($tmpname){try{throw ${INTERNAL_STATE_NAME}.handleException($tmpname);}`
 					});
+					insertions.push({
+						__proto__: null,
+						pos: node.body.end,
+						order: TO_LEFT,
+						code: `}`
+					});
+				} else {
+					const name = assertType(param, 'Identifier').name;
+					const cBody = assertType(node.body, 'BlockStatement');
+					if (cBody.body.length > 0) {
+						insertions.push({
+							__proto__: null,
+							pos: cBody.body[0].start,
+							order: TO_LEFT,
+							code: `${name}=${INTERNAL_STATE_NAME}.handleException(${name});`
+						});
+					}
 				}
 			}
 		} else if (nodeType === 'WithStatement') {
@@ -141,6 +157,8 @@ function transformer(args, body, isAsync, isGenerator, filename) {
 				if (internStateValiable === undefined || internStateValiable.start > node.start) {
 					internStateValiable = node;
 				}
+			} else if (node.name.startsWith(tmpname)) {
+				tmpname = node.name + "_UNIQUE";
 			}
 		} else if (nodeType === 'ImportExpression') {
 			insertions.push({
@@ -168,7 +186,7 @@ function transformer(args, body, isAsync, isGenerator, filename) {
 	let curr = 0;
 	for (let i = 0; i < insertions.length; i++) {
 		const change = insertions[i];
-		ncode += code.substring(curr, change.pos) + change.code;
+		ncode += code.substring(curr, change.pos) + change.code.replace(/\$tmpname/g, tmpname);
 		curr = change.pos;
 	}
 	ncode += code.substring(curr);

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -103,7 +103,7 @@ function transformer(args, body, isAsync, isGenerator, filename) {
 	const TO_RIGHT = 100;
 
 	let internStateValiable = undefined;
-	let tmpname = "VM2_INTERNAL_TMPNAME";
+	let tmpname = 'VM2_INTERNAL_TMPNAME';
 
 	acornWalkFull(ast, (node, state, type) => {
 		if (type === 'Function') {
@@ -158,7 +158,7 @@ function transformer(args, body, isAsync, isGenerator, filename) {
 					internStateValiable = node;
 				}
 			} else if (node.name.startsWith(tmpname)) {
-				tmpname = node.name + "_UNIQUE";
+				tmpname = node.name + '_UNIQUE';
 			}
 		} else if (nodeType === 'ImportExpression') {
 			insertions.push({


### PR DESCRIPTION
Object pattern can be used in catch clauses. Previously this triggered an error, now it is transformed from
```js
try{...} catch ({pattern}) {...}
```
to
```js
try{...} catch (tmp) {try{throw makeSafe(tmp);}catch ({pattern}) {...}}
```