### PR TITLE
feat: allow per-module choice for vm context

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Unlike `VM`, `NodeVM` allows you to require modules in the same way that you wou
 * `require.root` - Restricted path(s) where local modules can be required (default: every path).
 * `require.mock` - Collection of mock modules (both external or built-in).
 * `require.context` - `host` (default) to require modules in the host and proxy them into the sandbox. `sandbox` to load, compile, and require modules in the sandbox. Except for `events`, built-in modules are always required in the host and proxied into the sandbox.
+* `require.pathContext` - A callback allowing custom context to be determined per module. Parameters are the module name, and extension. The callback must return `host` or `sandbox` as per above.
 * `require.import` - An array of modules to be loaded into NodeVM on start.
 * `require.resolve` - An additional lookup function in case a module wasn't found in one of the traditional node lookup paths.
 * `require.customRequire` - Use instead of the `require` function to load modules from the host.

--- a/README.md
+++ b/README.md
@@ -141,8 +141,7 @@ Unlike `VM`, `NodeVM` allows you to require modules in the same way that you wou
 * `require.builtin` - Array of allowed built-in modules, accepts ["\*"] for all (default: none). **WARNING**: "\*" can be dangerous as new built-ins can be added.
 * `require.root` - Restricted path(s) where local modules can be required (default: every path).
 * `require.mock` - Collection of mock modules (both external or built-in).
-* `require.context` - `host` (default) to require modules in the host and proxy them into the sandbox. `sandbox` to load, compile, and require modules in the sandbox. Except for `events`, built-in modules are always required in the host and proxied into the sandbox.
-* `require.pathContext` - A callback allowing custom context to be determined per module. Parameters are the module name, and extension. The callback must return `host` or `sandbox` as per above.
+* `require.context` - `host` (default) to require modules in the host and proxy them into the sandbox. `sandbox` to load, compile, and require modules in the sandbox. `callback(moduleFilename, ext)` to dynamically choose a context per module. The default will be sandbox is nothing is specified. Except for `events`, built-in modules are always required in the host and proxied into the sandbox.
 * `require.import` - An array of modules to be loaded into NodeVM on start.
 * `require.resolve` - An additional lookup function in case a module wasn't found in one of the traditional node lookup paths.
 * `require.customRequire` - Use instead of the `require` function to load modules from the host.

--- a/lib/nodevm.js
+++ b/lib/nodevm.js
@@ -188,10 +188,10 @@ class NodeVM extends VM {
 	 * @param {string[]} [options.require.builtin=[]] - Array of allowed built-in modules, accepts ["*"] for all.
 	 * @param {(string|string[])} [options.require.root] - Restricted path(s) where local modules can be required. If omitted every path is allowed.
 	 * @param {Object} [options.require.mock] - Collection of mock modules (both external or built-in).
-	 * @param {("host"|"sandbox")} [options.require.context="host"] - <code>host</code> to require modules in host and proxy them to sandbox.
+	 * @param {("host"|"sandbox"|pathContextCallback)} [options.require.context="host"] -
+	 * <code>host</code> to require modules in host and proxy them to sandbox.
 	 * <code>sandbox</code> to load, compile and require modules in sandbox.
-	 * Builtin modules except <code>events</code> always required in host and proxied to sandbox.
-	 * @param {pathContextCallback} [options.require.pathContext] - A callback per-module path to customize "where" to load a module.
+	 * <code>pathContext(module, ext)</code> to choose a mode per module.
 	 * Builtin modules except <code>events</code> always required in host and proxied to sandbox.
 	 * @param {string[]} [options.require.import] - Array of modules to be loaded into NodeVM on start.
 	 * @param {resolveCallback} [options.require.resolve] - An additional lookup function in case a module wasn't

--- a/lib/nodevm.js
+++ b/lib/nodevm.js
@@ -24,7 +24,7 @@
  *
  * @callback pathContextCallback
  * @param {string} modulePath - The full path to the module filename being requested.
- * @param {string} extensionType - The type of extension (node, js, json)
+ * @param {string} extensionType - The module type (node = native, js = cjs/esm module)
  * @return {("host"|"sandbox")} The context for this module.
  */
 

--- a/lib/nodevm.js
+++ b/lib/nodevm.js
@@ -18,12 +18,12 @@
  */
 
 /**
- * This callback will be called to specify the context to use "per" module.
+ * This callback will be called to specify the context to use "per" module. Defaults to 'sandbox' if no return value provided.
  *
  * NOTE: many interoperating modules must live in the same context.
  *
  * @callback pathContextCallback
- * @param {string} moduleName - Name of the module requested.
+ * @param {string} modulePath - The full path to the module filename being requested.
  * @param {string} extensionType - The type of extension (node, js, json)
  * @return {("host"|"sandbox")} The context for this module.
  */
@@ -191,7 +191,7 @@ class NodeVM extends VM {
 	 * @param {("host"|"sandbox"|pathContextCallback)} [options.require.context="host"] -
 	 * <code>host</code> to require modules in host and proxy them to sandbox.
 	 * <code>sandbox</code> to load, compile and require modules in sandbox.
-	 * <code>pathContext(module, ext)</code> to choose a mode per module.
+	 * <code>pathContext(modulePath, ext)</code> to choose a mode per module (full path provided).
 	 * Builtin modules except <code>events</code> always required in host and proxied to sandbox.
 	 * @param {string[]} [options.require.import] - Array of modules to be loaded into NodeVM on start.
 	 * @param {resolveCallback} [options.require.resolve] - An additional lookup function in case a module wasn't

--- a/lib/nodevm.js
+++ b/lib/nodevm.js
@@ -17,6 +17,17 @@
  * @return {*} The required module object.
  */
 
+/**
+ * This callback will be called to specify the context to use "per" module.
+ *
+ * NOTE: many interoperating modules must live in the same context.
+ *
+ * @callback pathContextCallback
+ * @param {string} moduleName - Name of the module requested.
+ * @param {string} extensionType - The type of extension (node, js, json)
+ * @return {("host"|"sandbox")} The context for this module.
+ */
+
 const fs = require('fs');
 const pa = require('path');
 const {
@@ -180,11 +191,13 @@ class NodeVM extends VM {
 	 * @param {("host"|"sandbox")} [options.require.context="host"] - <code>host</code> to require modules in host and proxy them to sandbox.
 	 * <code>sandbox</code> to load, compile and require modules in sandbox.
 	 * Builtin modules except <code>events</code> always required in host and proxied to sandbox.
+	 * @param {pathContextCallback} [options.require.pathContext] - A callback per-module path to customize "where" to load a module.
+	 * Builtin modules except <code>events</code> always required in host and proxied to sandbox.
 	 * @param {string[]} [options.require.import] - Array of modules to be loaded into NodeVM on start.
 	 * @param {resolveCallback} [options.require.resolve] - An additional lookup function in case a module wasn't
 	 * found in one of the traditional node lookup paths.
 	 * @param {customRequire} [options.require.customRequire=require] - Custom require to require host and built-in modules.
-	 * @param {boolean} [option.require.strict=true] - Load required modules in strict mode.
+	 * @param {boolean} [options.require.strict=true] - Load required modules in strict mode.
 	 * @param {boolean} [options.nesting=false] -
 	 * <b>WARNING: Allowing this is a security risk as scripts can create a NodeVM which can require any host module.</b>
 	 * Allow nesting of VMs.

--- a/lib/resolver-compat.js
+++ b/lib/resolver-compat.js
@@ -332,7 +332,7 @@ function resolverFromOptions(vm, options, override, compiler) {
 		};
 	}
 
-	const pathContext = typeof options.context === 'function' ? ((module, ext) => options.context(module, ext) || 'host') : (() => context);
+	const pathContext = typeof options.context === 'function' ? ((module, ext) => options.context(module, ext) || 'sandbox') : (() => context);
 
 	if (typeof externalOpt !== 'object') {
 		return new DefaultResolver(fsOpt, builtins, checkPath, [], pathContext, newCustomResolver, hostRequire, compiler, strict);

--- a/lib/resolver-compat.js
+++ b/lib/resolver-compat.js
@@ -113,7 +113,7 @@ class LegacyResolver extends DefaultResolver {
 	loadJS(vm, mod, filename) {
 		filename = this.pathResolve(filename);
 		this.checkAccess(mod, filename);
-		if (this.pathContext(filename, 'js') === 'sandbox') {
+		if (this.pathContext(filename, 'js') !== 'host') {
 			const trustedMod = this.trustedMods.get(mod);
 			const script = this.readScript(filename);
 			vm.run(script, {filename, strict: true, module: mod, wrapper: 'none', dirname: trustedMod ? trustedMod.path : mod.path});
@@ -332,7 +332,7 @@ function resolverFromOptions(vm, options, override, compiler) {
 		};
 	}
 
-	const pathContext = typeof options.context === 'function' ? ((module, ext) => options.context(module, ext) || 'sandbox') : (() => context);
+	const pathContext = typeof context === 'function' ? context : (() => context);
 
 	if (typeof externalOpt !== 'object') {
 		return new DefaultResolver(fsOpt, builtins, checkPath, [], pathContext, newCustomResolver, hostRequire, compiler, strict);

--- a/lib/resolver-compat.js
+++ b/lib/resolver-compat.js
@@ -291,6 +291,8 @@ function resolverFromOptions(vm, options, override, compiler) {
 
 	const builtins = genBuiltinsFromOptions(vm, builtinOpt, mockOpt, override);
 
+	const pathContext = options.pathContext || (() => context);
+
 	if (!externalOpt) return new Resolver(fsOpt, builtins, [], hostRequire);
 
 	let checkPath;
@@ -344,7 +346,7 @@ function resolverFromOptions(vm, options, override, compiler) {
 		transitive = context === 'sandbox' && externalOpt.transitive;
 	}
 	externals = external.map(makeExternalMatcher);
-	return new LegacyResolver(fsOpt, builtins, checkPath, [], () => context, newCustomResolver, hostRequire, compiler, strict, externals, transitive);
+	return new LegacyResolver(fsOpt, builtins, checkPath, [], pathContext, newCustomResolver, hostRequire, compiler, strict, externals, transitive);
 }
 
 exports.resolverFromOptions = resolverFromOptions;

--- a/lib/resolver-compat.js
+++ b/lib/resolver-compat.js
@@ -291,8 +291,6 @@ function resolverFromOptions(vm, options, override, compiler) {
 
 	const builtins = genBuiltinsFromOptions(vm, builtinOpt, mockOpt, override);
 
-	const pathContext = options.pathContext || (() => context);
-
 	if (!externalOpt) return new Resolver(fsOpt, builtins, [], hostRequire);
 
 	let checkPath;
@@ -334,6 +332,8 @@ function resolverFromOptions(vm, options, override, compiler) {
 		};
 	}
 
+	const pathContext = typeof options.context === 'function' ? ((module, ext) => options.context(module, ext) || 'host') : (() => context);
+
 	if (typeof externalOpt !== 'object') {
 		return new DefaultResolver(fsOpt, builtins, checkPath, [], pathContext, newCustomResolver, hostRequire, compiler, strict);
 	}
@@ -343,7 +343,7 @@ function resolverFromOptions(vm, options, override, compiler) {
 		external = externalOpt;
 	} else {
 		external = externalOpt.modules;
-		transitive = context === 'sandbox' && externalOpt.transitive;
+		transitive = context !== 'host' && externalOpt.transitive;
 	}
 	externals = external.map(makeExternalMatcher);
 	return new LegacyResolver(fsOpt, builtins, checkPath, [], pathContext, newCustomResolver, hostRequire, compiler, strict, externals, transitive);

--- a/lib/resolver-compat.js
+++ b/lib/resolver-compat.js
@@ -335,7 +335,7 @@ function resolverFromOptions(vm, options, override, compiler) {
 	}
 
 	if (typeof externalOpt !== 'object') {
-		return new DefaultResolver(fsOpt, builtins, checkPath, [], () => context, newCustomResolver, hostRequire, compiler, strict);
+		return new DefaultResolver(fsOpt, builtins, checkPath, [], pathContext, newCustomResolver, hostRequire, compiler, strict);
 	}
 
 	let transitive = false;

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -197,7 +197,7 @@ class DefaultResolver extends Resolver {
 	loadJS(vm, mod, filename) {
 		filename = this.pathResolve(filename);
 		this.checkAccess(mod, filename);
-		if (this.pathContext(filename, 'js') === 'sandbox') {
+		if (this.pathContext(filename, 'js') !== 'host') {
 			const script = this.readScript(filename);
 			vm.run(script, {filename, strict: this.strict, module: mod, wrapper: 'none', dirname: mod.path});
 		} else {
@@ -216,7 +216,7 @@ class DefaultResolver extends Resolver {
 	loadNode(vm, mod, filename) {
 		filename = this.pathResolve(filename);
 		this.checkAccess(mod, filename);
-		if (this.pathContext(filename, 'node') === 'sandbox') throw new VMError('Native modules can be required only with context set to \'host\'.');
+		if (this.pathContext(filename, 'node') !== 'host') throw new VMError('Native modules can be required only with context set to \'host\'.');
 		const m = this.hostRequire(filename);
 		mod.exports = vm.readonly(m);
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vm2",
-  "version": "3.9.11",
+  "version": "3.9.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vm2",
-      "version": "3.9.11",
+      "version": "3.9.16",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.7.0",

--- a/test/nodevm.js
+++ b/test/nodevm.js
@@ -228,6 +228,23 @@ describe('modules', () => {
 		assert.ok(vm.run("require('module1')", __filename));
 	});
 
+	it('allows choosing a context by path', () => {
+		const vm = new NodeVM({
+			require: {
+				external: {
+					modules: ['mocha', 'module1'],
+				},
+				context(module) {
+					if (module === 'mocha') return 'host';
+					if (module === 'module1') return 'sandbox';
+				}
+			}
+		});
+
+		assert.ok(vm.run("require('module1')", __filename));
+		assert.ok(vm.run("require('mocha')", __filename));
+	});
+
 	it('can resolve paths based on a custom resolver', () => {
 		const vm = new NodeVM({
 			require: {


### PR DESCRIPTION
This PR exposes an underlying feature to choose the context of each module, instead of pre-determining the vm-wide setting. This feature allows you to load certain modules into the sandbox, while allowing most to remain in the host.