### PR TITLE
Fix: Block Object.prototype.__proto__ setter for consistency

### DIFF
--- a/lib/setup-sandbox.js
+++ b/lib/setup-sandbox.js
@@ -352,6 +352,22 @@ connect(localObject.prototype.__defineSetter__, host.Object.prototype.__defineSe
 connect(localObject.prototype.__lookupGetter__, host.Object.prototype.__lookupGetter__);
 connect(localObject.prototype.__lookupSetter__, host.Object.prototype.__lookupSetter__);
 
+// Block Object.prototype.__proto__ setter to prevent prototype chain manipulation
+// This is consistent with blocking Object.setPrototypeOf via ReadOnlyHandler
+const protoDescriptor = localReflectGetOwnPropertyDescriptor(localObject.prototype, '__proto__');
+if (protoDescriptor && protoDescriptor.set) {
+  localReflectDefineProperty(localObject.prototype, '__proto__', {
+    __proto__: null,
+    get: protoDescriptor.get,
+    set: function() {
+      // Silently ignore prototype changes, consistent with ReadOnlyHandler.setPrototypeOf returning false
+      return false;
+    },
+    enumerable: true,
+    configurable: false
+  });
+}
+
 /*
  * PrepareStackTrace sanitization
  */


### PR DESCRIPTION
## Summary
This fix addresses issue #548 where `Object.setPrototypeOf` is blocked but `Object.prototype.__proto__` setter was allowed, enabling prototype chain manipulation in the sandbox.

## Changes
- Added a custom setter for `Object.prototype.__proto__` that silently ignores prototype changes
- This is consistent with `ReadOnlyHandler.setPrototypeOf` which returns `false` to prevent prototype manipulation
- The fix preserves the getter functionality while blocking setter abuse

## Testing
- All existing tests pass (117 passing, 1 pending)
- Manually verified that `obj.__proto__ = Array.prototype` no longer changes the prototype
- Verified that `Object.getOwnPropertyNames(obj)` only returns own properties after attempted `__proto__` assignment

## Security Impact
This fix closes a security gap where attackers could use the `__proto__` setter to manipulate object prototypes, potentially enabling sandbox escape attacks that rely on prototype chain manipulation.