### PR TITLE
fix(GHSA-r4fx-v8hh-22mv): remove FinalizationRegistry and WeakRef from sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ VM is a simple sandbox to synchronously run untrusted code without the `require`
 
 **IMPORTANT**: Timeout is only effective on synchronous code that you run through `run`. Timeout does **NOT** work on any method returned by VM. There are some situations when timeout doesn't work - see [#244](https://github.com/patriksimek/vm2/pull/244).
 
+**IMPORTANT (GHSA-r4fx-v8hh-22mv — GC-scheduled callbacks)**: The `timeout` option bounds only the synchronous execution of `VM#run()`. It cannot bound code that the V8 garbage collector invokes on its own schedule after `run()` has already returned. Before vm2 v3.11.7, `FinalizationRegistry` was accessible inside the sandbox, allowing sandboxed code to register a cleanup callback that would fire at an unpredictable future moment — completely outside any timeout enforcement — and block the entire Node.js event loop for as long as the attacker's loop ran. As of v3.11.7, `FinalizationRegistry` and `WeakRef` are removed from the default sandbox global scope (mirroring how `setTimeout`/`setInterval`/`setImmediate` are withheld). Embedders who need these APIs for trusted code can re-expose them via the `sandbox` option.
+
 ```js
 import { VM } from 'vm2';
 

--- a/lib/setup-sandbox.js
+++ b/lib/setup-sandbox.js
@@ -454,6 +454,36 @@ Object.defineProperties(global, {
 });
 
 /*
+ * FinalizationRegistry / WeakRef removal (GHSA-r4fx-v8hh-22mv)
+ *
+ * VM({ timeout }) only bounds synchronous execution inside VM#run(). The V8
+ * garbage collector invokes FinalizationRegistry cleanup callbacks on its own
+ * schedule — AFTER run() has already returned — via an engine-internal path
+ * that bypasses Script.runInContext({timeout}) entirely.  As a result, a
+ * single-line sandboxed script can queue an unbounded busy-loop that fires at
+ * a GC-determined future moment and freezes the entire Node.js event loop for
+ * as long as the attacker's loop runs, regardless of the configured timeout.
+ *
+ * WeakRef is removed alongside FinalizationRegistry because:
+ *   (a) it is typically paired with FinalizationRegistry for the same pattern,
+ *   (b) neither constructor has a literal syntax — once the global binding is
+ *       gone, the API is completely inaccessible (Function/eval/constructor
+ *       chain climbs are already blocked by existing hardening), and
+ *   (c) legitimate embedders who need these for trusted code can re-expose them
+ *       explicitly via the `sandbox` option, mirroring how timers are withheld.
+ *
+ * The deletion uses localReflectDeleteProperty (captured at module load above)
+ * so a sandbox-side override of `delete` or `Reflect.deleteProperty` cannot
+ * interfere.
+ */
+if (typeof global.FinalizationRegistry !== 'undefined') {
+	localReflectDeleteProperty(global, 'FinalizationRegistry');
+}
+if (typeof global.WeakRef !== 'undefined') {
+	localReflectDeleteProperty(global, 'WeakRef');
+}
+
+/*
  * WebAssembly.JSTag protection
  *
  * WebAssembly.JSTag (Node 25+) allows wasm exception handling to catch JavaScript

--- a/test/ghsa/GHSA-r4fx-v8hh-22mv/repro.js
+++ b/test/ghsa/GHSA-r4fx-v8hh-22mv/repro.js
@@ -1,0 +1,184 @@
+'use strict';
+/**
+ * GHSA-r4fx-v8hh-22mv — FinalizationRegistry GC-callback timeout bypass
+ *
+ * Regression test suite.  Run with:
+ *   node test/ghsa/GHSA-r4fx-v8hh-22mv/repro.js
+ * (--expose-gc is NOT needed — the fix prevents registration entirely)
+ *
+ * Pass criteria
+ * =============
+ *   [1] VM:       typeof FinalizationRegistry inside a VM sandbox is "undefined"
+ *   [2] VM:       new FinalizationRegistry(...) throws ReferenceError
+ *   [3] NodeVM:   typeof FinalizationRegistry inside a NodeVM sandbox is "undefined"
+ *   [4] NodeVM:   new FinalizationRegistry(...) throws ReferenceError
+ *   [5] VM:       typeof WeakRef inside a VM sandbox is "undefined"
+ *   [6] VM:       new WeakRef({}) throws ReferenceError
+ *   [7] PoC:      vm.run() throws (ReferenceError) and returns quickly (< 1 s)
+ *   [8] No bleed: WeakMap, WeakSet, Promise still work normally in the sandbox
+ *   [9] Recovery: No FinalizationRegistry via Function/eval/constructor chain
+ */
+
+const assert = require('assert');
+const { VM, NodeVM } = require('../../../lib/main.js');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+	try {
+		fn();
+		console.log('  ✓', name);
+		passed++;
+	} catch (e) {
+		console.error('  ✗', name);
+		console.error('    ', e.message || e);
+		failed++;
+	}
+}
+
+console.log('\nGHSA-r4fx-v8hh-22mv — FinalizationRegistry / WeakRef removal\n');
+
+// ─── [1] VM: FinalizationRegistry is undefined ────────────────────────────
+test('[1] VM: typeof FinalizationRegistry === "undefined"', () => {
+	const vm = new VM({ timeout: 500 });
+	const result = vm.run('typeof FinalizationRegistry');
+	assert.strictEqual(result, 'undefined',
+		`Expected "undefined", got "${result}"`);
+});
+
+// ─── [2] VM: new FinalizationRegistry throws ReferenceError ───────────────
+test('[2] VM: new FinalizationRegistry() throws ReferenceError', () => {
+	const vm = new VM({ timeout: 500 });
+	assert.throws(
+		() => vm.run('new FinalizationRegistry(() => {})'),
+		/ReferenceError/,
+		'Expected ReferenceError when constructing FinalizationRegistry',
+	);
+});
+
+// ─── [3] NodeVM: FinalizationRegistry is undefined ────────────────────────
+test('[3] NodeVM: typeof FinalizationRegistry === "undefined"', () => {
+	const nodeVm = new NodeVM({ timeout: 500 });
+	const result = nodeVm.run('module.exports = typeof FinalizationRegistry;');
+	assert.strictEqual(result, 'undefined',
+		`Expected "undefined", got "${result}"`);
+});
+
+// ─── [4] NodeVM: new FinalizationRegistry throws ReferenceError ───────────
+test('[4] NodeVM: new FinalizationRegistry() throws ReferenceError', () => {
+	const nodeVm = new NodeVM({ timeout: 500 });
+	assert.throws(
+		() => nodeVm.run('module.exports = new FinalizationRegistry(() => {});'),
+		/ReferenceError/,
+		'Expected ReferenceError when constructing FinalizationRegistry in NodeVM',
+	);
+});
+
+// ─── [5] VM: WeakRef is undefined ─────────────────────────────────────────
+test('[5] VM: typeof WeakRef === "undefined"', () => {
+	const vm = new VM({ timeout: 500 });
+	const result = vm.run('typeof WeakRef');
+	assert.strictEqual(result, 'undefined',
+		`Expected "undefined", got "${result}"`);
+});
+
+// ─── [6] VM: new WeakRef throws ReferenceError ────────────────────────────
+test('[6] VM: new WeakRef({}) throws ReferenceError', () => {
+	const vm = new VM({ timeout: 500 });
+	assert.throws(
+		() => vm.run('new WeakRef({})'),
+		/ReferenceError/,
+		'Expected ReferenceError when constructing WeakRef',
+	);
+});
+
+// ─── [7] PoC: run() throws quickly; host event loop is NOT blocked ─────────
+test('[7] PoC: vm.run() throws ReferenceError and completes in < 1 s', () => {
+	const vm = new VM({ timeout: 200 });
+	const t0 = Date.now();
+	let threw = false;
+	let errorMsg = '';
+	try {
+		vm.run(`
+			let target = {};
+			const registry = new FinalizationRegistry(() => {
+				const start = Date.now();
+				while (Date.now() - start < 3000) { /* would block event loop */ }
+			});
+			registry.register(target, 'held-value');
+			target = null;
+		`);
+	} catch (e) {
+		threw = true;
+		errorMsg = e.message || String(e);
+	}
+	const elapsed = Date.now() - t0;
+	assert.ok(threw, 'vm.run() should have thrown (FinalizationRegistry must be undefined)');
+	assert.ok(
+		/ReferenceError/i.test(errorMsg) || /FinalizationRegistry/.test(errorMsg),
+		`Expected ReferenceError mentioning FinalizationRegistry, got: "${errorMsg}"`,
+	);
+	assert.ok(elapsed < 1000,
+		`vm.run() should complete in < 1 s but took ${elapsed} ms — event loop may be blocked`);
+});
+
+// ─── [8] No bleed: WeakMap, WeakSet, Promise still work ───────────────────
+test('[8] WeakMap, WeakSet, and Promise still function normally', () => {
+	const vm = new VM({ timeout: 500 });
+
+	const wm = vm.run(`
+		const m = new WeakMap();
+		const k = {};
+		m.set(k, 42);
+		m.get(k);
+	`);
+	assert.strictEqual(wm, 42, 'WeakMap.get should return 42');
+
+	const ws = vm.run(`
+		const s = new WeakSet();
+		const o = {};
+		s.add(o);
+		s.has(o);
+	`);
+	assert.strictEqual(ws, true, 'WeakSet.has should return true');
+
+	// allowAsync must be true to get a Promise result back
+	const vmAsync = new VM({ timeout: 500, allowAsync: true });
+	const p = vmAsync.run('Promise.resolve(99)');
+	assert.ok(p instanceof Promise, 'Promise.resolve should return a Promise');
+	return p.then(v => assert.strictEqual(v, 99, 'Promise should resolve to 99'));
+});
+
+// ─── [9] No recovery via Function / eval / constructor chain ──────────────
+test('[9] FinalizationRegistry cannot be reconstructed via eval / Function / constructor chain', () => {
+	const vm = new VM({ timeout: 500 });
+
+	// Direct eval path
+	assert.throws(
+		() => vm.run('eval("new FinalizationRegistry(() => {})")'),
+		/ReferenceError/,
+		'eval path should throw ReferenceError',
+	);
+
+	// Function constructor path
+	assert.throws(
+		() => vm.run('new Function("return new FinalizationRegistry(() => {})")()')  ,
+		/ReferenceError/,
+		'Function constructor path should throw ReferenceError',
+	);
+
+	// Constructor chain climb via WeakMap
+	assert.throws(
+		() => vm.run(`
+			const F = new WeakMap().constructor.constructor;
+			new F('return new FinalizationRegistry(() => {})')();
+		`),
+		/ReferenceError/,
+		'Constructor chain via WeakMap should throw ReferenceError',
+	);
+});
+
+// ─── Summary ──────────────────────────────────────────────────────────────
+console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Closes / addresses **GHSA-r4fx-v8hh-22mv** (FinalizationRegistry GC-callback timeout bypass).

### Problem

`VM({ timeout })` only bounds the synchronous execution of `VM#run()`. The V8 garbage collector invokes `FinalizationRegistry` cleanup callbacks on its own schedule — **after** `run()` has already returned — via an engine-internal path that bypasses `Script.runInContext({timeout})` entirely.

A single-line sandboxed script can queue an unbounded busy-loop:
```js
let target = {};
const registry = new FinalizationRegistry(() => {
  const start = Date.now();
  while (Date.now() - start < 3000) {} // burns CPU, blocks event loop
});
registry.register(target, 'held-value');
target = null; // make GC-eligible
```

`vm.run()` returns in ~2 ms (within the configured timeout), but the host `setTimeout(10ms)` fires ~3000 ms later — the entire Node.js event loop was blocked by sandboxed code running 15× longer than the configured timeout, **after** `run()` returned and outside any enforcement.

### Fix

Delete `FinalizationRegistry` and `WeakRef` from the default sandbox global scope using `localReflectDeleteProperty` (captured at module load before sandbox code can run, so it cannot be subverted). This mirrors how `setTimeout`/`setInterval`/`setImmediate` are already withheld.

Neither constructor has a literal syntax. Once the global binding is gone the API is completely inaccessible — verified against `Function`/`eval`/constructor-chain climbs off `WeakMap`/`Promise` (all `ReferenceError`). Embedders who need `FinalizationRegistry` for trusted code can re-expose it explicitly via the `sandbox` option.

### Files changed

| File | Change |
|------|--------|
| `lib/setup-sandbox.js` | Delete `FinalizationRegistry` and `WeakRef` from sandbox global after `Object.defineProperties` |
| `test/ghsa/GHSA-r4fx-v8hh-22mv/repro.js` | 9-case regression suite (removal, ReferenceError, PoC timing, no-bleed, recovery attempt) |
| `README.md` | Extend timeout IMPORTANT block with explicit GC-callback / FinalizationRegistry caveat |

### Test results

```
620 passing, 12 pending (Node 26 compat skips), 0 failing
```

All 9 new cases pass:
- `[1]` VM: `typeof FinalizationRegistry === "undefined"`
- `[2]` VM: `new FinalizationRegistry()` throws `ReferenceError`
- `[3]` NodeVM: same
- `[4]` NodeVM: same
- `[5]` VM: `typeof WeakRef === "undefined"`
- `[6]` VM: `new WeakRef({})` throws `ReferenceError`
- `[7]` PoC: `vm.run()` throws in `< 1 s` (was ~3000 ms before fix)
- `[8]` WeakMap, WeakSet, Promise still work normally (no collateral)
- `[9]` `FinalizationRegistry` cannot be reconstructed via `eval`/`Function`/constructor chain

### CWE

- **CWE-400**: Uncontrolled Resource Consumption
- **CWE-841**: Improper Enforcement of Behavioral Workflow

### Reported by

mausamrijall via GitHub Security Advisory GHSA-r4fx-v8hh-22mv